### PR TITLE
M590: SMS Encoding set to GSM

### DIFF
--- a/TinyGsmClientM590.h
+++ b/TinyGsmClientM590.h
@@ -290,6 +290,8 @@ public:
   }
 
   bool sendSMS(const String& number, const String& text) {
+    sendAT(GF("+CSCS=\"gsm\""));
+    waitResponse();
     sendAT(GF("+CMGF=1"));
     waitResponse();
     sendAT(GF("+CMGS=\""), number, GF("\""));


### PR DESCRIPTION
Enforce GSM encoding to be GSM, so you can sendSMS by String without
convert to UCS2 or HEX or others.