### PR TITLE
M590: Support PowerOff command

### DIFF
--- a/TinyGsmClientM590.h
+++ b/TinyGsmClientM590.h
@@ -233,6 +233,11 @@ public:
     return init();
   }
 
+  bool poweroff() {
+    sendAT(GF("+CPWROFF"));
+    return waitResponse(30000L) == 1;
+  }
+
   /*
    * SIM card & Networ Operator functions
    */


### PR DESCRIPTION
 - in order power off need use ON/OFF pin (sometimes markes as "BOOT") to GPIO and put HIGH before call this command.
 - in order to power on modem again need this GPIO put to LOW