### PR TITLE
SIM800L: Add GetBattPercent and radioStop functions.

### DIFF
--- a/TinyGsmClientSIM800.h
+++ b/TinyGsmClientSIM800.h
@@ -239,6 +239,18 @@ public:
     return init();
   }
 
+bool radiostop() {
+    if (!autoBaud()) {
+      return false;
+    }
+    sendAT(GF("+CFUN=0"));
+    if (waitResponse(10000L) != 1) {
+      return false;
+    }
+    delay(3000);
+    return true;
+  }
+
   /*
    * SIM card & Networ Operator functions
    */
@@ -522,6 +534,20 @@ public:
     streamSkipUntil(','); // Skip
 
     uint16_t res = stream.readStringUntil(',').toInt();
+    waitResponse();
+    return res;
+  }
+
+int getBattPercent() {
+      if (!autoBaud()) {
+      return false;
+    }
+    sendAT(GF("+CBC"));
+    if (waitResponse(GF(GSM_NL "+CBC:")) != 1) {
+      return false;
+    }
+    stream.readStringUntil(',');
+    int res = stream.readStringUntil(',').toInt();
     waitResponse();
     return res;
   }


### PR DESCRIPTION
Needed for GPS trackers which interact with HomeAssistant's json MQTT tracker component and for battery conservation while the device is stationary for long periods.