### PR TITLE
added sleep and wake-up functionality

### DIFF
--- a/TinyGsmClientSIM800.h
+++ b/TinyGsmClientSIM800.h
@@ -287,6 +287,12 @@ public:
     }
     return waitResponse() == 1;
   }
+  
+  //simple function to check if the module is responding (for example to check if woken up correctly)
+  bool getAttention(uint32_t timeout) {
+	sendAT(GF(""));
+	return waitResponse(timeout, GF(GSM_NL "OK"));
+  }
 
   /*
    * Power functions
@@ -322,6 +328,25 @@ public:
       return false;
     }
     delay(3000);
+    return true;
+  }
+  
+  /* During sleep, the SIM800 module has its serial communication disabled. In order to reestablish communication 
+     pull the DRT-pin of the SIM800 module LOW for at least 50ms. Then use this function to disable sleep mode. The
+     DTR-pin can then be released again. */
+  bool wakeup() {
+	sendAT(GF("+CSCLK=0"));
+	if (waitResponse(GF(GSM_NL "OK")) != 1) {
+	  return false;
+	}
+	return true;
+  }
+  
+  bool sleep() {
+    sendAT(GF("+CSCLK=1"));
+    if (waitResponse(GF(GSM_NL "OK")) != 1) {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
SIM800 modules have an easy to use sleep function. I added two functions to use this functionality. The DTR-pin needs to be used to wake the module up again, see comments in the code.