### PR TITLE
update GPS function

### DIFF
--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -69,7 +69,7 @@ public:
 
     sendAT(GF("+CGNSINF"));
     if (waitResponse(GF(GSM_NL "+CGNSINF:")) != 1) {
-      return false;
+      fix = false;
     }
 
     stream.readStringUntil(','); // mode


### PR DESCRIPTION
return all GPS informations also if position isn’t fix.

Problem:
If the position was not fix. the function returned nothing. So it was no table to see how many satellites are viewed/used.