### PR TITLE
Set an alphabet for SMS sending to "GSM" for SIM800/808 

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -655,6 +655,9 @@ public:
   bool sendSMS(const String& number, const String& text) {
     sendAT(GF("+CMGF=1"));
     waitResponse();
+    //Set GSM 7 bit default alphabet (3GPP TS 23.038)
+    sendAT(GF("+CSCS=\"GSM\""));
+    waitResponse();
     sendAT(GF("+CMGS=\""), number, GF("\""));
     if (waitResponse(GF(">")) != 1) {
       return false;


### PR DESCRIPTION
Set default alphabet to `GSM` for send SMS function as per AT command manual. 
Even now AllFunctions.ino won't work as the default alphabet was set to `HEX` in sendUSSD function and never changed again.