### PR TITLE
Added Network Time Fetching for SimXXX

### DIFF
--- a/examples/AllFunctions/AllFunctions.ino
+++ b/examples/AllFunctions/AllFunctions.ino
@@ -126,6 +126,12 @@ void loop() {
   String gsmLoc = modem.getGsmLocation();
   DBG("GSM location:", gsmLoc);
 
+  // This is only supported on SIMxxx series
+  String gsmTime = modem.getGSMDateTime(DATE_TIME);
+  DBG("GSM Time:", gsmTime);
+  String gsmDate = modem.getGSMDateTime(DATE_DATE);
+  DBG("GSM Date:", gsmDate);
+
   String ussd_balance = modem.sendUSSD("*111#");
   DBG("Balance (USSD):", ussd_balance);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -24,3 +24,6 @@ factoryReset	KEYWORD2
 #######################################
 # Literals (LITERAL1)
 #######################################
+DATE_FULL	LITERAL1
+DATE_TIME	LITERAL1
+DATE_DATE	LITERAL1

--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -39,6 +39,11 @@ enum RegStatus {
   REG_UNKNOWN      = 4,
 };
 
+enum DateTime {
+  DATE_FULL = 0,
+  DATE_TIME = 1,
+  DATE_DATE = 2
+};
 
 class TinyGsmSim800
 {
@@ -307,6 +312,13 @@ public:
     if (!testAT()) {
       return false;
     }
+    //Enable Local Time Stamp for getting network time
+    sendAT(GF("+CLTS=1"));
+    if (waitResponse(10000L) != 1) {
+      return false;
+    }
+    sendAT(GF("&W"));
+    waitResponse();
     sendAT(GF("+CFUN=0"));
     if (waitResponse(10000L) != 1) {
       return false;
@@ -716,6 +728,32 @@ public:
     String res = stream.readStringUntil('\n');
     waitResponse();
     res.trim();
+    return res;
+  }
+
+  /*
+   * Time functions
+   */
+  String getGSMDateTime(DateTime format) {
+    sendAT(GF("+CCLK?"));
+    if (waitResponse(2000L, GF(GSM_NL "+CCLK: \"")) != 1) {
+      return "";
+    }
+    
+    String res;
+
+    switch(format) {
+      case DATE_FULL:
+        res = stream.readStringUntil('"');
+      break;
+      case DATE_TIME:
+        streamSkipUntil(',');
+        res = stream.readStringUntil('"');
+      break;
+      case DATE_DATE:
+        res = stream.readStringUntil(',');
+      break;
+    }
     return res;
   }
 


### PR DESCRIPTION
Adds functionality to fetch the Date & Time from Network (you can also get this from the GPS Location, but this requires connection to APN)

The function is called _getGSMDateTime_ and it accepts a single parameter which is an enumeration to specify the format:

- DATE_FULL **Returns the full Date & Time** 
- DATE_TIME **Returns the Time only** 
- DATE_DATE **Returns the Date only** 