### PR TITLE
Added events to turn on Modem and set baud in 2 stages

### DIFF
--- a/examples/more/MKRGSM1400/MKRGSM1400.ino
+++ b/examples/more/MKRGSM1400/MKRGSM1400.ino
@@ -1,0 +1,166 @@
+/**************************************************************
+
+   This sketch connects to a website and downloads a page.
+   It can be used to perform HTTP/RESTful API calls.
+
+   TinyGSM Getting Started guide:
+     http://tiny.cc/tiny-gsm-readme
+
+ **************************************************************/
+
+// Select your modem:
+#define TINY_GSM_MODEM_UBLOX
+
+// Increase RX buffer if needed
+//#define TINY_GSM_RX_BUFFER 512
+
+#include <TinyGsmClient.h>
+
+// Uncomment this if you want to see all AT commands
+//#define DUMP_AT_COMMANDS
+
+// Set serial for debug console (to the Serial Monitor, default speed 115200)
+#define SerialMon Serial
+
+// Use Hardware Serial on Mega, Leonardo, Micro
+//#define SerialAT Serial1
+
+// or Software Serial on Uno, Nano
+//#include <SoftwareSerial.h>
+//SoftwareSerial SerialAT(2, 3); // RX, TX
+
+// Use Hardware Serial on MKR GSM
+#define SerialAT SerialGSM
+
+// Your GPRS credentials
+// Leave empty, if missing user or pass
+const char apn[]  = "YourAPN";
+const char user[] = "";
+const char pass[] = "";
+
+// Server details
+const char server[] = "vsh.pp.ua";
+const char resource[] = "/TinyGSM/logo.txt";
+const int  port = 80;
+
+#ifdef DUMP_AT_COMMANDS
+#include <StreamDebugger.h>
+StreamDebugger debugger(SerialAT, SerialMon);
+TinyGsm modem(debugger);
+#else
+TinyGsm modem(SerialAT);
+#endif
+
+TinyGsmClient client(modem);
+
+const int baud = 921600;
+
+void OnPowerOn(void* sender, EventArgs* e)
+{
+  // FOR THE MKR GSM 1400
+  // reset / powerup the modem
+  pinMode(GSM_RESETN, OUTPUT);
+  digitalWrite(GSM_RESETN, HIGH);
+  delay(100);
+  digitalWrite(GSM_RESETN, LOW);
+}
+
+void OnModemReady(void* sender, EventArgs* e)
+{
+  if (baud > 115200) {
+    modem.setBaud(baud);
+
+    SerialAT.end();
+    delay(100);
+    SerialAT.begin(baud);
+  }
+}
+
+void setup() {
+  // Set console baud rate
+  SerialMon.begin(115200);
+  while (!SerialMon) {}
+
+  modem.PowerOn    += OnPowerOn;
+  modem.ModemReady += OnModemReady;
+
+  // Set GSM module baud rate
+  SerialAT.begin( (baud > 115200) ? 115200 : baud);
+
+  // FOR THE MKR GSM 1400
+  // reset / powerup the modem
+  pinMode(GSM_RESETN, OUTPUT);
+  digitalWrite(GSM_RESETN, HIGH);
+  delay(100);
+  digitalWrite(GSM_RESETN, LOW);
+
+  // Restart takes quite some time
+  // To skip it, call init() instead of restart()
+  SerialMon.println(F("Initializing modem..."));
+  modem.init();
+
+  String modemInfo = modem.getModemInfo();
+  SerialMon.print(F("Modem: "));
+  SerialMon.println(modemInfo);
+
+  // Unlock your SIM card with a PIN
+  //modem.simUnlock("1234");
+}
+
+void loop() {
+  SerialMon.print(F("Waiting for network..."));
+  if (!modem.waitForNetwork()) {
+    SerialMon.println(" fail");
+    delay(10000);
+    return;
+  }
+  SerialMon.println(" OK");
+
+  SerialMon.print(F("Connecting to "));
+  SerialMon.print(apn);
+  if (!modem.gprsConnect(apn, user, pass)) {
+    SerialMon.println(" fail");
+    delay(10000);
+    return;
+  }
+  SerialMon.println(" OK");
+
+  SerialMon.print(F("Connecting to "));
+  SerialMon.print(server);
+  if (!client.connect(server, port)) {
+    SerialMon.println(" fail");
+    delay(10000);
+    return;
+  }
+  SerialMon.println(" OK");
+
+  // Make a HTTP GET request:
+  client.print(String("GET ") + resource + " HTTP/1.0\r\n");
+  client.print(String("Host: ") + server + "\r\n");
+  client.print("Connection: close\r\n\r\n");
+
+  unsigned long timeout = millis();
+  while (client.connected() && millis() - timeout < 10000L) {
+    // Print available data
+    while (client.available()) {
+      char c = client.read();
+      SerialMon.print(c);
+      timeout = millis();
+    }
+  }
+  SerialMon.println();
+
+  // Shutdown
+
+  client.stop();
+  SerialMon.println(F("Server disconnected"));
+
+  modem.gprsDisconnect();
+  SerialMon.println(F("GPRS disconnected"));
+
+  // Do nothing forevermore
+  while (true) {
+    delay(1000);
+  }
+}
+

--- a/src/TinyGsmClientUBLOX.h
+++ b/src/TinyGsmClientUBLOX.h
@@ -39,7 +39,6 @@ enum RegStatus {
   REG_UNKNOWN      = 4,
 };
 
-
 class TinyGsmU201
 {
 
@@ -193,6 +192,8 @@ public:
 };
 
 public:
+    Event<EventFunc> PowerOn;
+    Event<EventFunc> ModemReady;
 
 #ifdef GSM_DEFAULT_STREAM
   TinyGsmU201(Stream& stream = GSM_DEFAULT_STREAM)
@@ -212,13 +213,20 @@ public:
   }
 
   bool init(const char* pin = NULL) {
+      
+    PowerOn(this, NULL);
+
     if (!testAT()) {
       return false;
     }
+      
+    ModemReady(this, NULL);
+
     sendAT(GF("E0"));   // Echo Off
     if (waitResponse() != 1) {
       return false;
     }
+      
     int ret = getSimStatus();
     if (ret != SIM_READY && pin != NULL && strlen(pin) > 0) {
       simUnlock(pin);

--- a/src/TinyGsmCommon.h
+++ b/src/TinyGsmCommon.h
@@ -26,6 +26,7 @@
 #endif
 
 #include <TinyGsmFifo.h>
+#include <TinyGsmEvents.h>
 
 #ifndef TINY_GSM_YIELD
   #define TINY_GSM_YIELD() { delay(0); }

--- a/src/TinyGsmEvents.h
+++ b/src/TinyGsmEvents.h
@@ -1,0 +1,32 @@
+class EventArgs {};
+
+typedef void(*EventFunc)(void*, EventArgs*);
+
+template<typename F>
+class Event;
+
+template<class R>
+class Event<R(*)(void*, EventArgs*)>
+{
+	typedef R(*FuncType)(void*, EventArgs*);
+	FuncType ls;
+public:
+	Event<FuncType>& operator+=(FuncType t)
+	{
+		ls = t;
+		return *this;
+	}
+
+	Event<FuncType>& operator-=(FuncType t)
+	{
+		ls = NULL;
+		return *this;
+	}
+
+	void operator()(void* sender, EventArgs* b)
+	{
+		if (NULL != ls)
+			(*ls)(sender, b);
+	}
+};
+


### PR DESCRIPTION
The MKR GSM 1400 can achieve super high baudrates (921600), but needs to be started at max 155200. Once the modem is alive, speed can be increased over 155200. Events (or callbacks) are a nice way to 'jump out' of the init function to the sketch.

The event signature (void*, EventArgs*) is taken from c# events (https://docs.microsoft.com/en-us/dotnet/api/system.eventhandler?view=netframework-4.7.2), where the sender is the instance that called the event. EventArgs can be further subclassed to provide addtional methods and attributes for the callback

In the MKR GSM 1400 sample,  modem.setBaud(921600); could also have been written using:
TinyGSMY201* u201 = (TinyGSMY201*)sender;
u201->setBaud(baud)