### PR TITLE
Added sleep mode handling for SIM800. Only handles mode 2 for now.

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -395,6 +395,32 @@ public:
     return waitResponse() == 1;
   }
 
+  bool sleep(uint8_t sleepmode) // sleepmode = 1 || 2
+  {
+    sendAT(GF("+CSCLK="), sleepmode);
+    return waitResponse() == 1;
+  }
+
+  bool awaken(uint8_t sleepmode)
+  {
+    if (sleepmode == 1)
+    {
+      // TODO: Implement sleep mode 1
+    }
+    else if(sleepmode == 2)
+    {
+      for (uint8_t i = 0; i<10; i++)
+      {
+        sendAT(GF(""));
+        delay(50);
+      }
+      delay(100);
+      sendAT(GF("+CSCLK="), 0);
+      return waitResponse() == 1;
+    }
+    return false;
+  }
+
   /*
    * SIM card functions
    */


### PR DESCRIPTION
The SIM800 has [two sleep modes](https://www.raviyp.com/embedded/223-sim900-sim800-sleep-mode-at-commands), 1 and 2.

The only difference between them is the way the module enters and exits the sleep mode.

This pull request provides an intuitive API to put the module asleep or awaken it. The sleep mode is taken as an argument.

**Example:**
```
#define SLEEP_MODE 2
#define SLEEP_TIME 60000

void loop()
{
    if (!modem.sleep(SLEEP_MODE))
            handleSetAsleepError(); // fake function
    delay(SLEEP_TIME);
    if (!modem.awaken(SLEEP_MODE))
            handleAwakenError(); // fake function
}
```