### PR TITLE
Add sleep mode handling for SIM800

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -395,6 +395,33 @@ public:
     return waitResponse() == 1;
   }
 
+  bool sleep(uint8_t sleepmode) // sleepmode = 1 || 2
+  {
+    sendAT(GF("+CSCLK="), sleepmode);
+    return waitResponse() == 1;
+  }
+
+  bool awaken(uint8_t sleepmode)
+  {
+    if (sleepmode == 1)
+    {
+      // TODO
+    }
+    else if(sleepmode == 2)
+    {
+      // Sends bulk AT commands to awaken the serial of the module.
+      for (uint8_t i = 0; i<10; i++)
+      {
+        sendAT(GF(""));
+        delay(50);
+      }
+      delay(100);
+      sendAT(GF("+CSCLK="), 0);
+      return waitResponse() == 1;
+    }
+    return false;
+  }
+
   /*
    * SIM card functions
    */


### PR DESCRIPTION
The SIM800 has [two sleep modes](https://www.raviyp.com/embedded/223-sim900-sim800-sleep-mode-at-commands), 1 and 2.

Both have the same current consumption. The only difference is the way the module enters and exits the sleep.

This pull request provides an intuitive API to set asleep and awaken the SIM800 module. It takes the mode as an argument.

**Example:**
```
#define SLEEP_MODE 2
#define TIME_ASLEEP 60000

void loop()
{
    modem.sleep(SLEEP_MODE);
    delay(TIME_ASLEEP);
    modem.awaken(SLEEP_MODE);
}
```

Those two functions return a bool which can be used for error handling.

**TODO**: Implement awakening in mode 1.