### PR TITLE
Update TinyGsmClientSIM800.h

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -93,7 +93,7 @@ public:
     return connect(host.c_str(), port);
   }
   
-  #ifdef ESP32 || ESP8266
+  #ifdef ESP32 || ESP8266 || nodemcuv2 || esp01 || esp32dev
   virtual int connect(IPAddress ip, uint16_t port, int timeout)
   {
     throw "Method [virtual int connect(IPAddress ip, uint16_t port, int timeout)] is not implemented in TinyGsmClientSIM800.h";

--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -92,6 +92,18 @@ public:
     host += ip[3];
     return connect(host.c_str(), port);
   }
+  
+  #ifdef ESP32 || ESP8266
+  virtual int connect(IPAddress ip, uint16_t port, int timeout)
+  {
+    throw "Method [virtual int connect(IPAddress ip, uint16_t port, int timeout)] is not implemented in TinyGsmClientSIM800.h";
+  }
+
+  virtual int connect(const char *host, uint16_t port, int timeout)
+  {
+    throw "Method [virtual int connect(const char *host, uint16_t port, int timeout)] is not implemented in TinyGsmClientSIM800.h";
+  }
+  #endif
 
   virtual void stop() {
     TINY_GSM_YIELD();


### PR DESCRIPTION
In the base class Client.h of ESP32 board exists two abstract method 
    virtual int connect(IPAddress ip, uint16_t port, int timeout) =0;
    virtual int connect(const char *host, uint16_t port, int timeout) =0;

which is not implemented in GsmClient class. I've implemented it fo ESP32/ESP8266 with the exception generators for any case.