### PR TITLE
Exceeding socket`s _timeout should abort read operation.

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -844,6 +844,10 @@ protected:
       char c = strtol(buf, NULL, 16);
 #else
       while (!stream.available() && (millis() - startMillis < sockets[mux]->_timeout)) { TINY_GSM_YIELD(); }
+      if(millis() - startMillis >= sockets[mux]->_timeout){
+        DBG("### Timeout. Aborting read");
+        break;
+      }
       char c = stream.read();
 #endif
       sockets[mux]->rx.put(c);


### PR DESCRIPTION
Fixes #316.