### PR TITLE
[WIP] Use relative includes

### DIFF
--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -43,7 +43,7 @@
 #elif defined(TINY_GSM_MODEM_UBLOX)
   #define TINY_GSM_MODEM_HAS_GPRS
   #define TINY_GSM_MODEM_HAS_SSL
-  #include <TinyGsmClientUBLOX.h>
+  #include "TinyGsmClientUBLOX.h"
   typedef TinyGsmUBLOX TinyGsm;
   typedef TinyGsmUBLOX::GsmClient TinyGsmClient;
   typedef TinyGsmUBLOX::GsmClientSecure TinyGsmClientSecure;

--- a/src/TinyGsmClientUBLOX.h
+++ b/src/TinyGsmClientUBLOX.h
@@ -18,7 +18,7 @@
 
 #define TINY_GSM_MUX_COUNT 7
 
-#include <TinyGsmCommon.h>
+#include "TinyGsmCommon.h"
 
 #define GSM_NL "\r\n"
 static const char GSM_OK[] TINY_GSM_PROGMEM = "OK" GSM_NL;

--- a/src/TinyGsmCommon.h
+++ b/src/TinyGsmCommon.h
@@ -28,7 +28,7 @@
   #include <Client.h>
 #endif
 
-#include <TinyGsmFifo.h>
+#include "TinyGsmFifo.h"
 
 #ifndef TINY_GSM_YIELD_MS
   #define TINY_GSM_YIELD_MS 0


### PR DESCRIPTION
So that this library can reside in the sketch directory under `src/` rather than in the global libraries folder. This allows one to have a dedicated version of this library in use by the sketch, especially in cases where multiple versions of the library is available. This also allows one to have a specific version committed to git along with the sketch.

The library has been updated for the global includes and the Ublox modem types. Includes for other modem types still need to be done.