### PR TITLE
sleepEnableImpl. SIM800. Give the posibility of use the CSCLK=2 option

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -270,7 +270,7 @@ class TinyGsmSim800 : public TinyGsmModem<TinyGsmSim800>,
   // order to reestablish communication pull the DRT-pin of the SIM800 module
   // LOW for at least 50ms. Then use this function to disable sleep mode. The
   // DTR-pin can then be released again.
-  bool sleepEnableImpl(bool enable = true) {
+  bool sleepEnableImpl(byte enable = true) {
     sendAT(GF("+CSCLK="), enable);
     return waitResponse() == 1;
   }


### PR DESCRIPTION
sleepEnableImpl Give option to use +CSCLK=2 (only change function's parameter type from boolean to byte)

I have only changed enabled parameter type from boolean to type.
Every people that it is using with false and true, will be ok, but I, and others, could also use 2 as parameter to get +CSCLK=2 (another option to sleep SIM800).

I hope you could merge this little change 

Thanks

