### PR TITLE
FIX for issue #371: MC60 is not working with this library

### DIFF
--- a/src/TinyGsmClientMC60.h
+++ b/src/TinyGsmClientMC60.h
@@ -26,6 +26,9 @@
 #include "TinyGsmTCP.tpp"
 #include "TinyGsmTime.tpp"
 
+#include <Ethernet.h>
+
+
 #define GSM_NL "\r\n"
 static const char GSM_OK[] TINY_GSM_PROGMEM = "OK" GSM_NL;
 static const char GSM_ERROR[] TINY_GSM_PROGMEM = "ERROR" GSM_NL;
@@ -277,6 +280,10 @@ class TinyGsmMC60 : public TinyGsmModem<TinyGsmMC60>,
     sendAT(GF("+QIMUX=1"));
     if (waitResponse() != 1) { return false; }
 
+    // Modem is used as a client
+    sendAT(GF("+QISRVC=1"));
+    if (waitResponse() != 1) { return false; }
+
     // Start TCPIP Task and Set APN, User Name and Password
     sendAT("+QIREGAPP=\"", apn, "\",\"", user, "\",\"", pwd, "\"");
     if (waitResponse() != 1) { return false; }
@@ -369,6 +376,14 @@ class TinyGsmMC60 : public TinyGsmModem<TinyGsmMC60>,
   bool modemConnect(const char* host, uint16_t port, uint8_t mux,
                     bool ssl = false, int timeout_s = 75) {
     if (ssl) { DBG("SSL not yet supported on this module!"); }
+
+    // By default, MC60 expects IP address as 'host' parameter. 
+    // If it is a domain name, "AT+QIDNSIP=1" should be executed.
+    // "AT+QIDNSIP=0" is for dotted decimal IP address.
+    IPAddress addr;
+    sendAT(GF("+QIDNSIP="), (addr.fromString(host)?0:1));
+    if (waitResponse() != 1) { return false; }
+
     uint32_t timeout_ms = ((uint32_t)timeout_s) * 1000;
     sendAT(GF("+QIOPEN="), mux, GF(",\""), GF("TCP"), GF("\",\""), host,
            GF("\","), port);
@@ -388,7 +403,7 @@ class TinyGsmMC60 : public TinyGsmModem<TinyGsmMC60>,
     bool allAcknowledged = false;
     // bool failed = false;
     while (!allAcknowledged) {
-      sendAT(GF("+QISACK"));
+      sendAT(GF("+QISACK="), mux); // If 'mux' is not specified, MC60 returns 'ERRROR' (for QIMUX == 1)
       if (waitResponse(5000L, GF(GSM_NL "+QISACK:")) != 1) {
         return -1;
       } else {
@@ -532,13 +547,14 @@ class TinyGsmMC60 : public TinyGsmModem<TinyGsmMC60>,
           // read the number of packets in the buffer
           int8_t num_packets = streamGetIntBefore(',');
           // read the length of the current packet
-          int16_t len_packet = streamGetIntBefore('\n');
+          streamSkipUntil(','); // Skip the length of the current package in the buffer
+          int16_t len_total = streamGetIntBefore('\n'); // Total length of all packages
           if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux] &&
-              num_packets >= 0 && len_packet >= 0) {
-            sockets[mux]->sock_available = len_packet * num_packets;
+              num_packets >= 0 && len_total >= 0) {
+            sockets[mux]->sock_available = len_total;
           }
           data = "";
-          // DBG("### Got Data:", len_packet * num_packets, "on", mux);
+          // DBG("### Got Data:", len_total, "on", mux);
         } else if (data.endsWith(GF("CLOSED" GSM_NL))) {
           int8_t nl   = data.lastIndexOf(GSM_NL, data.length() - 8);
           int8_t coma = data.indexOf(',', nl + 2);


### PR DESCRIPTION
A batch of fixes for MC60, made according to documentation.

1) It is needed to specify for the modem that it should work as 'client' in gprsConnectImpl:

```
    // Modem is used as a client
    sendAT(GF("+QISRVC=1"));
    if (waitResponse() != 1) { return false; }
```

2) In modemConnect, before opening the connection, it is required to specify how 'host' parameter should be treated: as a host or as an IP ddress:
```

    // By default, MC60 expects IP address as 'host' parameter. 
    // If it is a domain name, "AT+QIDNSIP=1" should be executed.
    // "AT+QIDNSIP=0" is for dotted decimal IP address.
    IPAddress addr;
    sendAT(GF("+QIDNSIP="), (addr.fromString(host)?0:1));
    if (waitResponse() != 1) { return false; }
```

3) During sending process 'mux' should be passed to +QISACK if multiply connections used:

`      sendAT(GF("+QISACK="), mux); // If 'mux' is not specified, MC60 returns 'ERRROR' (for QIMUX == 1)
`

4) And it is a problem with capturing '+QIRDI' in waitResponse. Responce contains additional parameter. So the proper code will be:
```

        } else if (data.endsWith(
                       GF(GSM_NL "+QIRDI:"))) {  // TODO(?):  QIRD? or QIRDI?
          // +QIRDI: <id>,<sc>,<sid>,<num>,<len>,< tlen>
          streamSkipUntil(',');  // Skip the context
          streamSkipUntil(',');  // Skip the role
          // read the connection id
          int8_t mux = streamGetIntBefore(',');
          // read the number of packets in the buffer
          int8_t num_packets = streamGetIntBefore(',');
          // read the length of the current packet
          streamSkipUntil(','); // Skip the length of the current package in the buffer
          int16_t len_total = streamGetIntBefore('\n'); // Total length of all packages
          if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux] &&
              num_packets >= 0 && len_total >= 0) {
            sockets[mux]->sock_available = len_total;
          }
          data = "";
          // DBG("### Got Data:", len_total, "on", mux);
        } <...>

```


I have tested the modified code (attached) with D-IOT 2560 PRO based on Arduino Mega 2560 with integrated MC60 and examples/WebClient/WebClient.ino works fine for me by using Serial3 to communicate with MC60 ('#define SerialAT Serial3') 

** BUT with one change in example source code**: it is required to comment out setting "Connection: close" header line. For some reason, MC60 is not waiting for data to and closes the connection immediately. So, one trick and the example works fine:

`//client.print("Connection: close\r\n\r\n");
`