### PR TITLE
disable memory optimizations on ATmega4809

### DIFF
--- a/src/TinyGsmCommon.h
+++ b/src/TinyGsmCommon.h
@@ -41,7 +41,7 @@
   __attribute__((error("Not available on this modem type")))
 #define TINY_GSM_ATTR_NOT_IMPLEMENTED __attribute__((error("Not implemented")))
 
-#if defined(__AVR__)
+#if defined(__AVR__) && !defined(__AVR_ATmega4809__)
 #define TINY_GSM_PROGMEM PROGMEM
 typedef const __FlashStringHelper* GsmConstStr;
 #define GFP(x) (reinterpret_cast<GsmConstStr>(x))


### PR DESCRIPTION
This pull request disable the memory optimization defines for ATmega4809 (eg Arduino Nano Every)