### PR TITLE
use CEREG first to check registration status for BG96

### DIFF
--- a/src/TinyGsmClientBG96.h
+++ b/src/TinyGsmClientBG96.h
@@ -235,7 +235,16 @@ class TinyGsmBG96 : public TinyGsmModem<TinyGsmBG96>,
    */
  public:
   RegStatus getRegistrationStatus() {
-    return (RegStatus)getRegistrationStatusXREG("CREG");
+    // Check first for EPS registration
+    RegStatus epsStatus = (RegStatus)getRegistrationStatusXREG("CEREG");
+
+    // If we're connected on EPS, great!
+    if (epsStatus == REG_OK_HOME || epsStatus == REG_OK_ROAMING) {
+      return epsStatus;
+    } else {
+      // Otherwise, check generic network status
+      return (RegStatus)getRegistrationStatusXREG("CREG");
+    }
   }
 
  protected:


### PR DESCRIPTION
We have some issue with BG96 used in Japan.
We do not have 2G here and some operator provides SIM without SMS, another operator does not provide 3G, which causes `CREG` returns 0,2 (searching) or 0,3 (denied) even though PS attach succeeded.

To check registration status in such situation, we could use `CEREG` like it is done for "u-blox SARA-R4" module.
I referred `TinyGsmClientSaraR4.h` for this patch.

Could you consider to merge this, please?

Many thanks to @SRGDamia1 !