### PR TITLE
get LAC & Cell ID

### DIFF
--- a/src/TinyGsmClientSIM800.h
+++ b/src/TinyGsmClientSIM800.h
@@ -291,6 +291,31 @@ class TinyGsmSim800 : public TinyGsmModem<TinyGsmSim800>,
     return (RegStatus)getRegistrationStatusXREG("CREG");
   }
 
+  String getCellIdImpl()
+  {
+    sendAT(GF("+CREG=2"));
+    waitResponse(GF(GSM_NL "OK" GSM_NL));
+
+    sendAT(GF("+CREG?"));
+    if(waitResponse(GF(GSM_NL "+CREG:")) != 1)
+    {
+      return "";
+    }
+
+    streamSkipUntil(',');
+    streamSkipUntil('"');
+    String res = stream.readStringUntil('"');
+    streamSkipUntil(',');
+    streamSkipUntil('"');
+    res += stream.readStringUntil('"');
+
+    waitResponse();
+    res.trim();
+    sendAT(GF("+CREG=1"));
+    waitResponse(GF(GSM_NL "OK" GSM_NL));
+    return res;
+  }
+
  protected:
   bool isNetworkConnectedImpl() {
     RegStatus s = getRegistrationStatus();

--- a/src/TinyGsmModem.tpp
+++ b/src/TinyGsmModem.tpp
@@ -90,6 +90,11 @@ class TinyGsmModem {
   IPAddress localIP() {
     return thisModem().TinyGsmIpFromString(thisModem().getLocalIP());
   }
+  // Gets LOC and Cell ID
+  String getCellId()
+  {
+    return thisModem().getCellIdImpl();
+  }
 
   /*
    * CRTP Helper


### PR DESCRIPTION
This function returns LAC and Cell ID as 8 bytes hex format (example: "0179D60A"), first 4 bytes are LAC and last 4 bytes are CID.
![image](https://user-images.githubusercontent.com/16545031/104904289-4d737e80-5981-11eb-93ba-2ddf30fe00db.png)

according to this wiki [LCID/CID](https://wiki.opencellid.org/wiki/Talk:API#LCID.2FCID), CID is only 2 bytes and LCID is 4 bytes to whom it may concern.

Tested on **SIM808**.