### PR TITLE
Bc66

### DIFF
--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -81,6 +81,11 @@ typedef TinyGsmM590::GsmClientM590 TinyGsmClient;
 typedef TinyGsmMC60                TinyGsm;
 typedef TinyGsmMC60::GsmClientMC60 TinyGsmClient;
 
+#elif defined(TINY_GSM_MODEM_BC66)
+#include "TinyGsmClientBC66.h"
+typedef TinyGsmBC66                TinyGsm;
+typedef TinyGsmBC66::GsmClientBC66 TinyGsmClient;
+
 #elif defined(TINY_GSM_MODEM_ESP8266)
 #define TINY_GSM_MODEM_HAS_WIFI
 #include "TinyGsmClientESP8266.h"

--- a/src/TinyGsmClientBC66.h
+++ b/src/TinyGsmClientBC66.h
@@ -573,7 +573,7 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool configureSSLImpl(uint8 contextId, uint8 connectId, String cmd, uint8 arg = 0)
+  bool configureSSLImpl(uint8_t contextId, uint8_t connectId, String cmd, uint8_t arg = 0)
   {
     // From SSL Docu of Bc66
     // <contextID> aka sslconectId - Integer type. SSL context index. The range is 1-3.
@@ -582,14 +582,14 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     // 0 No authentication
     // 1 Manage server authentication
     // 2 Manage server and client authentication if requested by the remote server
-    uint8 sslconnectId = connectId;
-    uint8 sslcontextId = contextId;
+    uint8_t sslconnectId = connectId;
+    uint8_t sslcontextId = contextId;
     if(sslcontextId < 1 || sslcontextId > 3 || sslconnectId > 5) {
       DBG("CONTEXTID/CONNECTID OUT OF RANGE!");
       return false;
     }
     if(cmd.compareTo("seclevel") == 0) {
-      uint8 seclvl = arg;
+      uint8_t seclvl = arg;
       if( seclvl > 2) {
         DBG("SECLEVEL OUT OF RANGE!");
         return false;
@@ -627,17 +627,17 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
   /*
    * MQTT related functions
    */
-  bool configureMqttImpl(String cmd, uint8 arg1, uint8 arg2, uint8 arg3 = 0, uint8 arg4 = 0)
+  bool configureMqttImpl(String cmd, uint8_t arg1, uint8_t arg2, uint8_t arg3 = 0, uint8_t arg4 = 0)
   {
     // From TCP Docu of Bc66
     // <contextID> aka tcpcontextId - Integer type. Context ID. The range is 1-3.
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
     if(cmd.compareTo("ssl") == 0) {
       // modem.configureMqtt("ssl",tcpconnectId,enable,sslcontextId,sslconnectId)
-      uint8 tcpconnectId = arg1;
-      uint8 enable = arg2 == 1; // 0 or 1
-      uint8 sslcontextId = arg3;
-      uint8 sslconnectId = arg4;
+      uint8_t tcpconnectId = arg1;
+      uint8_t enable = arg2 == 1; // 0 or 1
+      uint8_t sslcontextId = arg3;
+      uint8_t sslconnectId = arg4;
       if(tcpconnectId > 4 || sslcontextId < 1 || sslcontextId > 3 || sslconnectId > 5)
       {
         DBG("TCPCONNECTID/SSLCONNECTID/SSLCONTEXTID OUT OF RANGE!");
@@ -649,8 +649,8 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     }
     else if(cmd.compareTo("version") == 0) {
       // modem.configureMqtt("version",tcpconnectId,mqttVersion)
-      uint8 tcpconnectId = arg1;
-      uint8 mqttVersion = arg2;
+      uint8_t tcpconnectId = arg1;
+      uint8_t mqttVersion = arg2;
       if(tcpconnectId > 4 || mqttVersion < 3 || mqttVersion > 4)
       {
         DBG("TCPCONNECTID/MQTTVERSION OUT OF RANGE!");
@@ -667,16 +667,16 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
       // <pkt_timeout> Integer type. Timeout of the packet delivery. The range is 1-60. The default value is 10. Unit: second.
       // <retry_times> Integer type. Retry times when packet delivery times out. The range is 0-10. The default value is 3.
       // <timeout_notice> Integer type. Whether to report timeout message when transmitting packet. 0 Not report, 1 Report
-      uint8 tcpconnectId = arg1;
+      uint8_t tcpconnectId = arg1;
     }
     */
     return false;
   }
 
-  bool openMqttImpl(uint8 connectId, String servername, uint16 serverport) {
+  bool openMqttImpl(uint8_t connectId, String servername, uint16_t serverport) {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4)
     {
       DBG("TCPCONNECTID OUT OF RANGE!");
@@ -704,10 +704,10 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool connectMqttImpl(uint8 connectId, String clientname, String username = "", String password = "") {
+  bool connectMqttImpl(uint8_t connectId, String clientname, String username = "", String password = "") {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4)
     {
       DBG("TCPCONNECTID OUT OF RANGE!");
@@ -743,11 +743,11 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool disconnectMqttImpl(uint8 connectId)
+  bool disconnectMqttImpl(uint8_t connectId)
   {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4)
     {
       DBG("TCPCONNECTID OUT OF RANGE!");
@@ -772,11 +772,11 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     }
     return false;
   }
-  bool closeMqttImpl(uint8 connectId)
+  bool closeMqttImpl(uint8_t connectId)
   {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4)
     {
       DBG("TCPCONNECTID OUT OF RANGE!");
@@ -802,13 +802,13 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool subscribeMqttImpl(uint8 connectId, uint16 msgId, String topic, uint8 qos = 0)
+  bool subscribeMqttImpl(uint8_t connectId, uint16_t msgId, String topic, uint8_t qos = 0)
   {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
     // <msgID> Integer type. Message identifier of packet. The range is 1-65535
     // <qos> Integer type. The QoS level at which the client wants to publish the messages (0 at most once, 1 at least once, 2 exactly once)
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4 || msgId < 1 || qos > 2)
     {
       DBG("TCPCONNECTID/MSGID/QOS OUT OF RANGE!");
@@ -838,12 +838,12 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool unsubscribeMqttImpl(uint8 connectId, uint16 msgId, String topic)
+  bool unsubscribeMqttImpl(uint8_t connectId, uint16_t msgId, String topic)
   {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
     // <msgID> Integer type. Message identifier of packet. The range is 1-65535
-    uint8 tcpconnectId = connectId;
+    uint8_t tcpconnectId = connectId;
     if(tcpconnectId > 4 || msgId < 1)
     {
       DBG("TCPCONNECTID/MSGID OUT OF RANGE!");
@@ -873,16 +873,16 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
     return false;
   }
 
-  bool publishMqttImpl(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos = 0, uint8 retain = 0)
+  bool publishMqttImpl(uint8_t connectId, uint16_t msgId, String topic, String msg, uint8_t qos = 0, uint8_t retain = 0)
   {
     // From TCP Docu of Bc66
     // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
     // <msgID> Integer type. Message identifier of packet. The range is 1-65535
     // <qos> Integer type. The QoS level at which the client wants to publish the messages (0 at most once, 1 at least once, 2 exactly once)
     // <retain> Integer type. Whether or not the server will retain the message after it has been delivered to the current subscribers. (0 server will not retain mgs, 1 will retain the message)
-    uint8 tcpconnectId = connectId;
-    uint16 tmsgId = msgId;
-    uint8 tqos = qos;
+    uint8_t tcpconnectId = connectId;
+    uint16_t tmsgId = msgId;
+    uint8_t tqos = qos;
     if(tcpconnectId > 4 || tmsgId < 1 || tqos > 2 || retain > 1)
     {
       DBG("TCPCONNECTID/MSGID/QOS/RETAIN OUT OF RANGE!");
@@ -967,9 +967,9 @@ class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
 
         if(m_cb) {
           int len = msg.length();
-          uint8 payload[1024];
+          uint8_t payload[1024];
           msg.getBytes(payload, len);
-          m_cb(const_cast<char*>(topic.c_str()), reinterpret_cast<uint8*>(payload), len);
+          m_cb(const_cast<char*>(topic.c_str()), reinterpret_cast<uint8_t*>(payload), len);
         }
       }
     }

--- a/src/TinyGsmClientBC66.h
+++ b/src/TinyGsmClientBC66.h
@@ -1,0 +1,857 @@
+/**
+ * @file       TinyGsmClientBC66.h
+ * @author     Volodymyr Shymanskyy
+ * @license    LGPL-3.0
+ * @copyright  Copyright (c) 2016 Volodymyr Shymanskyy
+ * @date       Nov 2016
+ *
+ * @MC60 support added by Tamas Dajka 2017.10.15 - with fixes by Sara Damiano
+ *
+ */
+
+#ifndef SRC_TINYGSMCLIENTBC66_H_
+#define SRC_TINYGSMCLIENTBC66_H_
+// #pragma message("TinyGSM:  TinyGsmClientBC66")
+
+// #define TINY_GSM_DEBUG Serial
+
+#define TINY_GSM_MUX_COUNT 6
+#define TINY_GSM_BUFFER_READ_NO_CHECK
+
+#include "TinyGsmBattery.tpp"
+#include "TinyGsmCalling.tpp"
+#include "TinyGsmGPRS.tpp"
+#include "TinyGsmModem.tpp"
+#include "TinyGsmMqtt.tpp"
+#include "TinyGsmSMS.tpp"
+#include "TinyGsmSSL.tpp"
+#include "TinyGsmTCP.tpp"
+#include "TinyGsmTime.tpp"
+
+#define GSM_NL "\r\n"
+static const char GSM_OK[] TINY_GSM_PROGMEM    = "OK" GSM_NL;
+static const char GSM_ERROR[] TINY_GSM_PROGMEM = "ERROR" GSM_NL;
+#if defined       TINY_GSM_DEBUG
+static const char GSM_CME_ERROR[] TINY_GSM_PROGMEM = GSM_NL "+CME ERROR:";
+static const char GSM_CMS_ERROR[] TINY_GSM_PROGMEM = GSM_NL "+CMS ERROR:";
+#endif
+
+enum RegStatus {
+  REG_NO_RESULT    = -1,
+  REG_UNREGISTERED = 0,
+  REG_SEARCHING    = 2,
+  REG_DENIED       = 3,
+  REG_OK_HOME      = 1,
+  REG_OK_ROAMING   = 5,
+  REG_UNKNOWN      = 4,
+};
+
+class TinyGsmBC66 : public TinyGsmModem<TinyGsmBC66>,
+                    public TinyGsmGPRS<TinyGsmBC66>,
+                    public TinyGsmTCP<TinyGsmBC66, TINY_GSM_MUX_COUNT>,
+                    public TinyGsmCalling<TinyGsmBC66>,
+                    public TinyGsmSMS<TinyGsmBC66>,
+                    public TinyGsmSSL<TinyGsmBC66>,
+                    public TinyGsmTime<TinyGsmBC66>,
+                    public TinyGsmBattery<TinyGsmBC66>,
+                    public TinyGsmMqtt<TinyGsmBC66>  {
+  friend class TinyGsmModem<TinyGsmBC66>;
+  friend class TinyGsmGPRS<TinyGsmBC66>;
+  friend class TinyGsmTCP<TinyGsmBC66, TINY_GSM_MUX_COUNT>;
+  friend class TinyGsmCalling<TinyGsmBC66>;
+  friend class TinyGsmSMS<TinyGsmBC66>;
+  friend class TinyGsmSSL<TinyGsmBC66>;
+  friend class TinyGsmTime<TinyGsmBC66>;
+  friend class TinyGsmBattery<TinyGsmBC66>;
+  friend class TinyGsmMqtt<TinyGsmBC66>;
+
+  /*
+   * Inner Client
+   */
+ public:
+  class GsmClientBC66 : public GsmClient {
+    friend class TinyGsmBC66;
+
+   public:
+    GsmClientBC66() {}
+
+    explicit GsmClientBC66(TinyGsmBC66& modem, uint8_t mux = 0) {
+      init(&modem, mux);
+    }
+
+    bool init(TinyGsmBC66* modem, uint8_t mux = 0) {
+      this->at       = modem;
+      sock_available = 0;
+      sock_connected = false;
+
+      if (mux < TINY_GSM_MUX_COUNT) {
+        this->mux = mux;
+      } else {
+        this->mux = (mux % TINY_GSM_MUX_COUNT);
+      }
+      at->sockets[this->mux] = this;
+
+      return true;
+    }
+
+   public:
+    virtual int connect(const char* host, uint16_t port, int timeout_s) {
+      stop();
+      TINY_GSM_YIELD();
+      rx.clear();
+      sock_connected = at->modemConnect(host, port, mux, false, timeout_s);
+      return sock_connected;
+    }
+    TINY_GSM_CLIENT_CONNECT_OVERRIDES
+
+    void stop(uint32_t maxWaitMs) {
+      uint32_t startMillis = millis();
+      dumpModemBuffer(maxWaitMs);
+      at->sendAT(GF("+QICLOSE="), mux);
+      sock_connected = false;
+      at->waitResponse((maxWaitMs - (millis() - startMillis)), GF("CLOSED"),
+                       GF("CLOSE OK"), GF("ERROR"));
+    }
+    void stop() override {
+      stop(75000L);
+    }
+
+    /*
+     * Extended API
+     */
+
+    String remoteIP() TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  };
+
+  /*
+   * Inner Secure Client
+   */
+
+  /*
+    class GsmClientSecureMC60 : public GsmClientBC66
+    {
+    public:
+      GsmClientSecure() {}
+
+      GsmClientSecure(TinyGsmBC66& modem, uint8_t mux = 0)
+       : GsmClient(modem, mux)
+      {}
+
+
+    public:
+      int connect(const char* host, uint16_t port, int timeout_s) override {
+        stop();
+        TINY_GSM_YIELD();
+        rx.clear();
+        sock_connected = at->modemConnect(host, port, mux, true, timeout_s);
+        return sock_connected;
+      }
+      TINY_GSM_CLIENT_CONNECT_OVERRIDES
+    };
+ */
+
+  /*
+   * Constructor
+   */
+ public:
+  explicit TinyGsmBC66(Stream& stream) : stream(stream) {
+    memset(sockets, 0, sizeof(sockets));
+  }
+
+  /*
+   * Basic functions
+   */
+ protected:
+  bool initImpl(const char* pin = NULL) {
+    DBG(GF("### TinyGSM Version:"), TINYGSM_VERSION);
+    DBG(GF("### TinyGSM Compiled Module:  TinyGsmClientBC66"));
+
+    if (!testAT()) { return false; }
+
+    // sendAT(GF("&FZ"));  // Factory + Reset
+    // waitResponse();
+
+    sendAT(GF("E0"));  // Echo Off
+    if (waitResponse() != 1) { return false; }
+
+#ifdef TINY_GSM_DEBUG
+    sendAT(GF("+CMEE=2"));  // turn on verbose error codes
+#else
+    sendAT(GF("+CMEE=0"));  // turn off error codes
+#endif
+    waitResponse();
+
+    DBG(GF("### Modem:"), getModemName());
+
+    // Enable network time synchronization - not available on BC66
+    //sendAT(GF("+QNITZ=1"));
+    //if (waitResponse(10000L) != 1) { return false; }
+
+    SimStatus ret = getSimStatus();
+    // if the sim isn't ready and a pin has been provided, try to unlock the sim
+    if (ret != SIM_READY && pin != NULL && strlen(pin) > 0) {
+      simUnlock(pin);
+      return (getSimStatus() == SIM_READY);
+    } else {
+      // if the sim is ready, or it's locked but no pin has been provided,
+      // return true
+      return (ret == SIM_READY || ret == SIM_LOCKED);
+    }
+  }
+
+  /*
+   * Power functions
+   */
+ protected:
+  bool restartImpl() {
+    if (!testAT()) { return false; }
+    if (!setPhoneFunctionality(0)) { return false; }
+    if (!setPhoneFunctionality(1, true)) { return false; }
+    delay(3000);
+    return init();
+  }
+
+  bool powerOffImpl() {
+    sendAT(GF("+QPOWD=1"));
+    return waitResponse(GF("NORMAL POWER DOWN")) == 1;
+  }
+
+  // When entering into sleep mode is enabled, DTR is pulled up, and WAKEUP_IN
+  // is pulled up, the module can directly enter into sleep mode.If entering
+  // into sleep mode is enabled, DTR is pulled down, and WAKEUP_IN is pulled
+  // down, there is a need to pull the DTR pin and the WAKEUP_IN pin up first,
+  // and then the module can enter into sleep mode.
+  bool sleepEnableImpl(bool enable = true) {
+    sendAT(GF("+QSCLK="), enable);
+    return waitResponse() == 1;
+  }
+
+  bool setPhoneFunctionalityImpl(uint8_t fun, bool reset = false) {
+    sendAT(GF("+CFUN="), fun, reset ? ",1" : "");
+    return waitResponse(10000L) == 1;
+  }
+
+  /*
+   * Generic network functions
+   */
+ public:
+  // original MC60
+  RegStatus getRegistrationStatus() {
+    return (RegStatus)getRegistrationStatusXREG("CEREG");
+  }
+
+ protected:
+  bool isNetworkConnectedImpl() {
+    RegStatus s = getRegistrationStatus();
+    return (s == REG_OK_HOME || s == REG_OK_ROAMING);
+  }
+
+  String getLocalIPImpl() {
+    return m_localIP.toString();
+  }
+
+  bool waitForNetworkImpl(uint32_t timeout_ms = 60000L) {
+    for (uint32_t start = millis(); millis() - start < timeout_ms;) {
+      if (waitResponse(2000L, GF(GSM_NL "+IP:")) != 1) {
+        continue;
+      } else {
+        // connection ID
+        uint8_t aaa = streamGetIntBefore('.');
+        uint8_t bbb = streamGetIntBefore('.');
+        uint8_t ccc = streamGetIntBefore('.');
+        uint8_t ddd = streamGetIntBefore('\n');
+        m_localIP = IPAddress(aaa,bbb,ccc,ddd);
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  /*
+   * GPRS functions
+   */
+ protected:
+  bool gprsConnectImpl(const char* apn, const char* user = NULL,
+                       const char* pwd = NULL) {
+    gprsDisconnect();
+
+    // select foreground context 0 = VIRTUAL_UART_1
+    sendAT(GF("+QIFGCNT=0"));
+    if (waitResponse() != 1) { return false; }
+
+    // Select GPRS (=1) as the Bearer
+    sendAT(GF("+QICSGP=1,\""), apn, GF("\",\""), user, GF("\",\""), pwd,
+           GF("\""));
+    if (waitResponse() != 1) { return false; }
+
+    // Define PDP context - is this necessary?
+    sendAT(GF("+CGDCONT=1,\"IP\",\""), apn, '"');
+    waitResponse();
+
+    // Activate PDP context - is this necessary?
+    sendAT(GF("+CGACT=1,1"));
+    waitResponse(60000L);
+
+    // Select TCP/IP transfer mode - NOT transparent mode
+    sendAT(GF("+QIMODE=0"));
+    if (waitResponse() != 1) { return false; }
+
+    // Enable multiple TCP/IP connections
+    sendAT(GF("+QIMUX=1"));
+    if (waitResponse() != 1) { return false; }
+
+    // Modem is used as a client
+    sendAT(GF("+QISRVC=1"));
+    if (waitResponse() != 1) { return false; }
+
+    // Start TCPIP Task and Set APN, User Name and Password
+    sendAT("+QIREGAPP=\"", apn, "\",\"", user, "\",\"", pwd, "\"");
+    if (waitResponse() != 1) { return false; }
+
+    // Activate GPRS/CSD Context
+    sendAT(GF("+QIACT"));
+    if (waitResponse(60000L) != 1) { return false; }
+
+    // Check that we have a local IP address
+    if (localIP() == IPAddress(0, 0, 0, 0)) { return false; }
+
+    // Set Method to Handle Received TCP/IP Data
+    // Mode=2 - Output a notification statement:
+    // +QIRDI: <id>,<sc>,<sid>,<num>,<len>,< tlen>
+    sendAT(GF("+QINDI=2"));
+    if (waitResponse() != 1) { return false; }
+
+    return true;
+  }
+
+  bool gprsDisconnectImpl() {
+    sendAT(GF("+QIDEACT"));  // Deactivate the bearer context
+    return waitResponse(60000L, GF("DEACT OK"), GF("ERROR")) == 1;
+  }
+
+  /*
+   * SIM card functions
+   */
+ protected:
+  SimStatus getSimStatusImpl(uint32_t timeout_ms = 10000L) {
+    for (uint32_t start = millis(); millis() - start < timeout_ms;) {
+      sendAT(GF("+CPIN?"));
+      if (waitResponse(GF(GSM_NL "+CPIN:")) != 1) {
+        delay(1000);
+        continue;
+      }
+      int8_t status = waitResponse(GF("READY"), GF("SIM PIN"), GF("SIM PUK"),
+                                   GF("NOT INSERTED"), GF("PH_SIM PIN"),
+                                   GF("PH_SIM PUK"));
+      waitResponse();
+      switch (status) {
+        case 2:
+        case 3: return SIM_LOCKED;
+        case 5:
+        case 6: return SIM_ANTITHEFT_LOCKED;
+        case 1: return SIM_READY;
+        default: return SIM_ERROR;
+      }
+    }
+    return SIM_ERROR;
+  }
+
+  /*
+   * Phone Call functions
+   */
+ protected:
+  // Can follow all of the phone call functions from the template
+
+  /*
+   * Messaging functions
+   */
+ protected:
+  // Can follow all template functions
+
+ public:
+  /** Delete all SMS */
+  bool deleteAllSMS() {
+    sendAT(GF("+QMGDA=6"));
+    if (waitResponse(waitResponse(60000L, GF("OK"), GF("ERROR")) == 1)) {
+      return true;
+    }
+    return false;
+  }
+
+  /*
+   * Time functions
+   */
+ protected:
+  // Can follow the standard CCLK function in the template
+
+  /*
+   * Battery functions
+   */
+  // Can follow battery functions as in the template
+
+  /*
+   * Client related functions
+   */
+ protected:
+  bool modemConnect(const char* host, uint16_t port, uint8_t mux,
+                    bool ssl = false, int timeout_s = 75) {
+    if (ssl) { DBG("SSL not yet supported on this module!"); }
+
+    // By default, MC60 expects IP address as 'host' parameter.
+    // If it is a domain name, "AT+QIDNSIP=1" should be executed.
+    // "AT+QIDNSIP=0" is for dotted decimal IP address.
+    IPAddress addr;
+    sendAT(GF("+QIDNSIP="), (addr.fromString(host) ? 0 : 1));
+    if (waitResponse() != 1) { return false; }
+
+    uint32_t timeout_ms = ((uint32_t)timeout_s) * 1000;
+    sendAT(GF("+QIOPEN="), mux, GF(",\""), GF("TCP"), GF("\",\""), host,
+           GF("\","), port);
+    int8_t rsp = waitResponse(timeout_ms, GF("CONNECT OK" GSM_NL),
+                              GF("CONNECT FAIL" GSM_NL),
+                              GF("ALREADY CONNECT" GSM_NL));
+    return (1 == rsp);
+  }
+
+  int16_t modemSend(const void* buff, size_t len, uint8_t mux) {
+    sendAT(GF("+QISEND="), mux, ',', (uint16_t)len);
+    if (waitResponse(GF(">")) != 1) { return 0; }
+    stream.write(reinterpret_cast<const uint8_t*>(buff), len);
+    stream.flush();
+    if (waitResponse(GF(GSM_NL "SEND OK")) != 1) { return 0; }
+
+    bool allAcknowledged = false;
+    // bool failed = false;
+    while (!allAcknowledged) {
+      sendAT(GF("+QISACK="), mux);  // If 'mux' is not specified, MC60 returns
+                                    // 'ERRROR' (for QIMUX == 1)
+      if (waitResponse(5000L, GF(GSM_NL "+QISACK:")) != 1) {
+        return -1;
+      } else {
+        streamSkipUntil(','); /** Skip total */
+        streamSkipUntil(','); /** Skip acknowledged data size */
+        if (streamGetIntBefore('\n') == 0) { allAcknowledged = true; }
+      }
+    }
+    waitResponse(5000L);
+
+    // streamSkipUntil(','); // Skip mux
+    // return streamGetIntBefore('\n');
+
+    return len;  // TODO(?): verify len/ack
+  }
+
+  size_t modemRead(size_t size, uint8_t mux) {
+    if (!sockets[mux]) return 0;
+    // TODO(?):  Does this even work????
+    // AT+QIRD=<id>,<sc>,<sid>,<len>
+    // id = GPRS context number = 0, set in GPRS connect
+    // sc = role in connection = 1, client of connection
+    // sid = index of connection = mux
+    // len = maximum length of data to retrieve
+    sendAT(GF("+QIRD=0,1,"), mux, ',', (uint16_t)size);
+    // If it replies only OK for the write command, it means there is no
+    // received data in the buffer of the connection.
+    int8_t res = waitResponse(GF("+QIRD:"), GFP(GSM_OK), GFP(GSM_ERROR));
+    if (res == 1) {
+      streamSkipUntil(':');  // skip IP address
+      streamSkipUntil(',');  // skip port
+      streamSkipUntil(',');  // skip connection type (TCP/UDP)
+      // read the real length of the retrieved data
+      uint16_t len = streamGetIntBefore('\n');
+      // It's possible that the real length available is less than expected
+      // This is quite likely if the buffer is broken into packets - which may
+      // be different sizes.
+      // If so, make sure we make sure we re-set the amount of data available.
+      if (len < size) { sockets[mux]->sock_available = len; }
+      for (uint16_t i = 0; i < len; i++) {
+        moveCharFromStreamToFifo(mux);
+        sockets[mux]->sock_available--;
+        // ^^ One less character available after moving from modem's FIFO to our
+        // FIFO
+      }
+      waitResponse();  // ends with an OK
+      // DBG("### READ:", len, "from", mux);
+      return len;
+    } else {
+      sockets[mux]->sock_available = 0;
+      return 0;
+    }
+  }
+
+  // Not possible to check the number of characters remaining in buffer
+  size_t modemGetAvailable(uint8_t) {
+    return 0;
+  }
+
+  bool modemGetConnected(uint8_t mux) {
+    sendAT(GF("+QISTATE=1,"), mux);
+    // +QISTATE: 0,"TCP","151.139.237.11",80,5087,4,1,0,0,"uart1"
+
+    if (waitResponse(GF("+QISTATE:")) != 1) { return false; }
+
+    streamSkipUntil(',');                  // Skip mux
+    streamSkipUntil(',');                  // Skip socket type
+    streamSkipUntil(',');                  // Skip remote ip
+    streamSkipUntil(',');                  // Skip remote port
+    streamSkipUntil(',');                  // Skip local port
+    int8_t res = streamGetIntBefore(',');  // socket state
+
+    waitResponse();
+
+    // 0 Initial, 1 Opening, 2 Connected, 3 Listening, 4 Closing
+    return 2 == res;
+  }
+
+  /*
+   * SSL related functions
+   */
+  protected:
+  bool addCertificateAsStringImpl(String certificatestring)
+  {
+    if(certificatestring.length() > 0) {
+      m_sslServerCertificate = certificatestring;
+      return true;
+    }
+    return false;
+  }
+
+  bool configureSSLImpl(uint8 contextId, uint8 connectId, String cmd, uint8 arg = 0)
+  {
+    // From SSL Docu of Bc66
+    // <contextID> aka sslconectId - Integer type. SSL context index. The range is 1-3.
+    // <connectID> aka sslconnectId - Integer type. SSL connect index. The range is 0-5.
+    // <seclevel> Integer type. Authentication mode.
+    // 0 No authentication
+    // 1 Manage server authentication
+    // 2 Manage server and client authentication if requested by the remote server
+    uint8 sslconnectId = connectId;
+    uint8 sslcontextId = contextId;
+    if(sslcontextId < 1 || sslcontextId > 3 || sslconnectId > 5) {
+      DBG("CONTEXTID/CONNECTID OUT OF RANGE!");
+      return false;
+    }
+    if(cmd.compareTo("seclevel") == 0) {
+      uint8 seclvl = arg;
+      if( seclvl > 2) {
+        DBG("SECLEVEL OUT OF RANGE!");
+        return false;
+      }
+      sendAT(GF("+QSSLCFG="), contextId, GF(","), connectId, GF(",\""), GF("seclevel"), GF("\","), seclvl);
+      if (waitResponse() != 1) { return false; }
+      return true;
+    }
+    else if(cmd.compareTo("cacert") == 0) {
+      if(m_sslServerCertificate.length() == 0) {
+        DBG("SSL CERTIFICATE EMPTY!");
+        return false;
+      }
+      sendAT(GF("+QSSLCFG="), contextId, GF(","), connectId, GF(",\""), GF("cacert"), GF("\""));
+      if (waitResponse(GF(">")) != 1) { return false; }
+
+      // chunked in 64-byte packets...
+      int sz = 0; int chnk = 64; int len = m_sslServerCertificate.length();
+      while(sz < len)
+      {
+        int to = sz+chnk-1 > len ? len : sz+chnk-1;
+        stream.print(m_sslServerCertificate.substring(sz,to).c_str());
+        sz = to;
+        delay(50);
+      }
+      // all at once
+      // stream.print(m_sslServerCertificate.c_str());  // Actually send the message
+      stream.write(static_cast<char>(0x1A));  // Terminate the message
+      stream.flush();
+      return waitResponse(5000L) == 1;
+    }
+    return false;
+  }
+
+  /*
+   * MQTT related functions
+   */
+  bool configureMqttImpl(String cmd, uint8 arg1, uint8 arg2, uint8 arg3 = 0, uint8 arg4 = 0)
+  {
+    // From TCP Docu of Bc66
+    // <contextID> aka tcpcontextId - Integer type. Context ID. The range is 1-3.
+    // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
+    if(cmd.compareTo("ssl") == 0) {
+      // modem.configureMqtt("ssl",tcpconnectId,enable,sslcontextId,sslconnectId)
+      uint8 tcpconnectId = arg1;
+      uint8 enable = arg2 == 1; // 0 or 1
+      uint8 sslcontextId = arg3;
+      uint8 sslconnectId = arg4;
+      if(tcpconnectId > 4 || sslcontextId < 1 || sslcontextId > 3 || sslconnectId > 5)
+      {
+        DBG("TCPCONNECTID/SSLCONNECTID/SSLCONTEXTID OUT OF RANGE!");
+        return false;
+      }
+      sendAT(GF("+QMTCFG="), GF("\""), GF("ssl"), GF("\","), tcpconnectId, GF(","), enable, GF(","), sslcontextId, GF(","), sslconnectId);
+      if (waitResponse() != 1) { return false; }
+      return true;
+    }
+    else if(cmd.compareTo("version") == 0) {
+      // modem.configureMqtt("version",tcpconnectId,mqttVersion)
+      uint8 tcpconnectId = arg1;
+      uint8 mqttVersion = arg2;
+      if(tcpconnectId > 4 || mqttVersion < 3 || mqttVersion > 4)
+      {
+        DBG("TCPCONNECTID/MQTTVERSION OUT OF RANGE!");
+        return false;
+      }
+      sendAT(GF("+QMTCFG="), GF("\""), GF("version"), GF("\","), tcpconnectId, GF(","), mqttVersion);
+      if (waitResponse() != 1) { return false; }
+      return true;
+    }
+    /*
+    else if (cmd.compareTo("timeout") == 0)
+    {
+      // AT+QMTCFG="timeout",<TCP_connectID>[,<pkt_timeout>,<retry_times>,<timeout_notice>]
+      // <pkt_timeout> Integer type. Timeout of the packet delivery. The range is 1-60. The default value is 10. Unit: second.
+      // <retry_times> Integer type. Retry times when packet delivery times out. The range is 0-10. The default value is 3.
+      // <timeout_notice> Integer type. Whether to report timeout message when transmitting packet. 0 Not report, 1 Report
+      uint8 tcpconnectId = arg1;
+    }
+    */
+    return false;
+  }
+
+  bool openMqttImpl(uint8 connectId, String servername, uint16 serverport) {
+    // From TCP Docu of Bc66
+    // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
+    uint8 tcpconnectId = connectId;
+    if(tcpconnectId > 4)
+    {
+      DBG("TCPCONNECTID OUT OF RANGE!");
+      return false;
+    }
+    sendAT(GF("+QMTOPEN="), tcpconnectId, GF(",\""), servername.c_str(), GF("\","), serverport);
+    if (waitResponse(5000L) != 1) { return false; }
+
+    // +QMTOPEN: 3,0
+    for (uint32_t start = millis(); millis() - start < 75000L;) {
+      if (waitResponse(2000L, GF(GSM_NL "+QMTOPEN:")) != 1) {
+        continue;
+      } else {
+        // connection ID
+        streamSkipUntil(','); // instead of int8_t mux = streamGetIntBefore(','); // UNUSED
+        // read the result (0 if ok, -1 if bad)
+        int8_t result = streamGetIntBefore('\n');
+        if (result == 0) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool connectMqttImpl(uint8 connectId, String clientname, String username = "", String password = "") {
+    // From TCP Docu of Bc66
+    // <connectID> aka tcpconnectId - Integer type. Socket service index. The range is 0-4.
+    uint8 tcpconnectId = connectId;
+    if(tcpconnectId > 4)
+    {
+      DBG("TCPCONNECTID OUT OF RANGE!");
+      return false;
+    }
+    if(username.length() > 0 || password.length() > 0)
+    {
+      DBG("USER/PASSWORD AUTH NOT IMPLEMENTED!");
+      return false;
+    }
+
+    sendAT(GF("+QMTCONN="), tcpconnectId, GF(",\""), clientname.c_str(), GF("\""));
+    if (waitResponse(5000L) != 1) { return false; }
+
+    // +QMTCONN: 3,0,0
+    for (uint32_t start = millis(); millis() - start < 60000L;) {
+      if (waitResponse(2000L, GF(GSM_NL "+QMTCONN:")) != 1) {
+        continue;
+      } else {
+        // connection ID
+        streamSkipUntil(','); // instead of int8_t mux = streamGetIntBefore(',');
+        // read the result (0 ok, 1 retransmit, 2 failed)
+        int8_t result = streamGetIntBefore(',');
+        // read the retcode (0 accepted, 1 protocol bad, 2 identifier reject, 3 refused (unavail), 4 bad user/pwd,  5 unauthorized
+        int8_t retcode = streamGetIntBefore('\n');
+        if (result == 0 && retcode == 0) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+
+  /*
+   * Utilities
+   */
+ public:
+  // TODO(vshymanskyy): Optimize this!
+  int8_t waitResponse(uint32_t timeout_ms, String& data,
+                      GsmConstStr r1 = GFP(GSM_OK),
+                      GsmConstStr r2 = GFP(GSM_ERROR),
+#if defined TINY_GSM_DEBUG
+                      GsmConstStr r3 = GFP(GSM_CME_ERROR),
+                      GsmConstStr r4 = GFP(GSM_CMS_ERROR),
+#else
+                      GsmConstStr r3 = NULL, GsmConstStr r4 = NULL,
+#endif
+                      GsmConstStr r5 = NULL, GsmConstStr r6 = NULL) {
+    /*String r1s(r1); r1s.trim();
+    String r2s(r2); r2s.trim();
+    String r3s(r3); r3s.trim();
+    String r4s(r4); r4s.trim();
+    String r5s(r5); r5s.trim();
+    String r6s(r6); r6s.trim();
+    DBG("### ..:", r1s, ",", r2s, ",", r3s, ",", r4s, ",", r5s, ",", r6s);*/
+    data.reserve(64);
+    uint8_t  index       = 0;
+    uint32_t startMillis = millis();
+    do {
+      TINY_GSM_YIELD();
+      while (stream.available() > 0) {
+        TINY_GSM_YIELD();
+        int8_t a = stream.read();
+        if (a <= 0) continue;  // Skip 0x00 bytes, just in case
+        data += static_cast<char>(a);
+        if (r1 && data.endsWith(r1)) {
+          index = 1;
+          goto finish;
+        } else if (r2 && data.endsWith(r2)) {
+          index = 2;
+          goto finish;
+        } else if (r3 && data.endsWith(r3)) {
+#if defined TINY_GSM_DEBUG
+          if (r3 == GFP(GSM_CME_ERROR)) {
+            streamSkipUntil('\n');  // Read out the error
+          }
+#endif
+          index = 3;
+          goto finish;
+        } else if (r4 && data.endsWith(r4)) {
+          index = 4;
+          goto finish;
+        } else if (r5 && data.endsWith(r5)) {
+          index = 5;
+          goto finish;
+        } else if (r6 && data.endsWith(r6)) {
+          index = 6;
+          goto finish;
+        } else if (data.endsWith(
+                       GF(GSM_NL "+QIRDI:"))) {  // TODO(?):  QIRD? or QIRDI?
+          // +QIRDI: <id>,<sc>,<sid>,<num>,<len>,< tlen>
+          streamSkipUntil(',');  // Skip the context
+          streamSkipUntil(',');  // Skip the role
+          // read the connection id
+          int8_t mux = streamGetIntBefore(',');
+          // read the number of packets in the buffer
+          int8_t num_packets = streamGetIntBefore(',');
+          // read the length of the current packet
+          streamSkipUntil(
+              ',');  // Skip the length of the current package in the buffer
+          int16_t len_total =
+              streamGetIntBefore('\n');  // Total length of all packages
+          if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux] &&
+              num_packets >= 0 && len_total >= 0) {
+            sockets[mux]->sock_available = len_total;
+          }
+          data = "";
+          // DBG("### Got Data:", len_total, "on", mux);
+        } else if (data.endsWith(GF("CLOSED" GSM_NL))) {
+          int8_t nl   = data.lastIndexOf(GSM_NL, data.length() - 8);
+          int8_t coma = data.indexOf(',', nl + 2);
+          int8_t mux  = data.substring(nl + 2, coma).toInt();
+          if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux]) {
+            sockets[mux]->sock_connected = false;
+          }
+          data = "";
+          DBG("### Closed: ", mux);
+        } else if (data.endsWith(GF("+QNITZ:"))) {
+          streamSkipUntil('\n');  // URC for time sync
+          DBG("### Network time updated.");
+          data = "";
+        }
+        /*else if(data.startsWith(GF(GSM_NL "+IP:")))
+        {
+          DBG("TODO: SHOULD BE CHANGED!!!!!");
+          // Serial.println("IP NEEDS TO BE PARSED HERE???");
+          index = 6;
+        }
+        else if(data.endsWith(GF(GSM_NL "+QMTOPEN:")))
+        {
+            // +QMTOPEN: <id>,<res>
+            // read the connection id
+            int8_t mux = streamGetIntBefore(',');
+            // read the result (0 if ok, -1 if bad)
+            int8_t result = streamGetIntBefore('\n');
+            data = "";
+        }
+        else if(data.endsWith(GF(GSM_NL "+QMTCONN:")))
+        {
+          // +QMTCONN: <id>,<res>
+          // read the connection id
+          int8_t mux = streamGetIntBefore(',');
+          // read the result (0 ok, 1 retransmit, 2 failed)
+          int8_t result = streamGetIntBefore(',');
+          // read the retcode (0 accepted, 1 protocol bad, 2 identifier reject, 3 refused (unavail), 4 bad user/pwd,  5 unauthorized
+          int8_t retcode = streamGetIntBefore('\n');
+          data = "";
+        }*/
+      }
+    } while (millis() - startMillis < timeout_ms);
+  finish:
+    if (!index) {
+      data.trim();
+      if (data.length()) { DBG("### Unhandled:", data); }
+      data = "";
+    }
+    // data.replace(GSM_NL, "/");
+    // DBG('<', index, '>', data);
+    return index;
+  }
+
+  int8_t waitResponse(uint32_t timeout_ms, GsmConstStr r1 = GFP(GSM_OK),
+                      GsmConstStr r2 = GFP(GSM_ERROR),
+#if defined TINY_GSM_DEBUG
+                      GsmConstStr r3 = GFP(GSM_CME_ERROR),
+                      GsmConstStr r4 = GFP(GSM_CMS_ERROR),
+#else
+                      GsmConstStr r3 = NULL, GsmConstStr r4 = NULL,
+#endif
+                      GsmConstStr r5 = NULL, GsmConstStr r6 = NULL) {
+    String data;
+    return waitResponse(timeout_ms, data, r1, r2, r3, r4, r5, r6);
+  }
+
+  int8_t waitResponse(GsmConstStr r1 = GFP(GSM_OK),
+                      GsmConstStr r2 = GFP(GSM_ERROR),
+#if defined TINY_GSM_DEBUG
+                      GsmConstStr r3 = GFP(GSM_CME_ERROR),
+                      GsmConstStr r4 = GFP(GSM_CMS_ERROR),
+#else
+                      GsmConstStr r3 = NULL, GsmConstStr r4 = NULL,
+#endif
+                      GsmConstStr r5 = NULL, GsmConstStr r6 = NULL) {
+    return waitResponse(1000, r1, r2, r3, r4, r5, r6);
+  }
+
+ public:
+  Stream& stream;
+
+ // BC66 specific internals
+ private:
+  IPAddress m_localIP;
+  String m_sslServerCertificate;
+
+ protected:
+  GsmClientBC66* sockets[TINY_GSM_MUX_COUNT];
+  const char*    gsmNL = GSM_NL;
+};
+
+#endif  // SRC_TINYGSMCLIENTBC66_H_

--- a/src/TinyGsmModem.tpp
+++ b/src/TinyGsmModem.tpp
@@ -200,7 +200,7 @@ class TinyGsmModem {
   bool waitForNetworkImpl(uint32_t timeout_ms = 60000L) {
     for (uint32_t start = millis(); millis() - start < timeout_ms;) {
       if (thisModem().isNetworkConnected()) { return true; }
-      delay(250);
+      delay(1000);
     }
     return false;
   }
@@ -343,7 +343,13 @@ class TinyGsmModem {
              !thisModem().stream.available()) {
         TINY_GSM_YIELD();
       }
-      if (thisModem().stream.read() == c) { return true; }
+      const char read = thisModem().stream.read();
+      if (read == c) { return true; }
+      /*
+      else {
+        Serial.print("\nNOT USED: "); Serial.print(read); Serial.print("\n");
+      }
+      */
     }
     return false;
   }

--- a/src/TinyGsmMqtt.tpp
+++ b/src/TinyGsmMqtt.tpp
@@ -23,28 +23,28 @@ class TinyGsmMqtt {
   /*
    * MQTT functions
    */
-  bool configureMqtt(String cmd, uint8 arg1, uint8 arg2, uint8 arg3 = 0, uint8 arg4 = 0) {
+  bool configureMqtt(String cmd, uint8_t arg1, uint8_t arg2, uint8_t arg3 = 0, uint8_t arg4 = 0) {
     return thisModem().configureMqttImpl(cmd, arg1, arg2, arg3, arg4);
   }
-  bool openMqtt(uint8 connectId, String servername, uint16 serverport) {
+  bool openMqtt(uint8_t connectId, String servername, uint16_t serverport) {
     return thisModem().openMqttImpl(connectId, servername, serverport);
   }
-  bool connectMqtt(uint8 connectId, String clientname, String username = "", String password = "") {
+  bool connectMqtt(uint8_t connectId, String clientname, String username = "", String password = "") {
     return thisModem().connectMqttImpl(connectId, clientname, username, password);
   }
-  bool disconnectMqtt(uint8 connectId) {
+  bool disconnectMqtt(uint8_t connectId) {
     return thisModem().disconnectMqttImpl(connectId);
   }
-  bool closeMqtt(uint8 connectId) {
+  bool closeMqtt(uint8_t connectId) {
     return thisModem().closeMqttImpl(connectId);
   }
-  bool publishMqtt(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos = 0, uint8 retain = 0) {
+  bool publishMqtt(uint8_t connectId, uint16_t msgId, String topic, String msg, uint8_t qos = 0, uint8_t retain = 0) {
     return thisModem().publishMqttImpl(connectId, msgId, topic, msg, qos, retain);
   }
-  bool subscribeMqtt(uint8 connectId, uint16 msgId, String topic, uint8 qos = 0) {
+  bool subscribeMqtt(uint8_t connectId, uint16_t msgId, String topic, uint8_t qos = 0) {
     return thisModem().subscribeMqttImpl(connectId, msgId, topic, qos);
   }
-  bool unsubscribeMqtt(uint8 connectId, uint16 msgId, String topic) {
+  bool unsubscribeMqtt(uint8_t connectId, uint16_t msgId, String topic) {
     return thisModem().unsubscribeMqttImpl(connectId, msgId, topic);
   }
   void setRecvCallbackMqtt(MQTT_CALLBACK_SIGNATURE_T callback) {
@@ -69,14 +69,14 @@ class TinyGsmMqtt {
    * MQTT functions
    */
  protected:
-  bool configureMqttImpl(String cmd, uint8 arg1, uint8 arg2, uint8 arg3, uint8 arg4) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool openMqttImpl(uint8 connectId, String servername, uint16 serverport) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool connectMqttImpl(uint8 connectId, String clientname, String username, String password) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool disconnectMqttImpl(uint8 connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool closeMqttImpl(uint8 connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool subscribeMqttImpl(uint8 connectId, uint16 msgId, String topic, uint8 qos) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool unsubscribeMqttImpl(uint8 connectId, uint16 msgId, String topic) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool publishMqttImpl(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos, uint8 retain) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool configureMqttImpl(String cmd, uint8_t arg1, uint8_t arg2, uint8_t arg3, uint8_t arg4) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool openMqttImpl(uint8_t connectId, String servername, uint16_t serverport) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool connectMqttImpl(uint8_t connectId, String clientname, String username, String password) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool disconnectMqttImpl(uint8_t connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool closeMqttImpl(uint8_t connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool subscribeMqttImpl(uint8_t connectId, uint16_t msgId, String topic, uint8_t qos) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool unsubscribeMqttImpl(uint8_t connectId, uint16_t msgId, String topic) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool publishMqttImpl(uint8_t connectId, uint16_t msgId, String topic, String msg, uint8_t qos, uint8_t retain) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   void setRecvCallbackMqttImpl(MQTT_CALLBACK_SIGNATURE_T callback) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   void loopMqttImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
 };

--- a/src/TinyGsmMqtt.tpp
+++ b/src/TinyGsmMqtt.tpp
@@ -15,7 +15,7 @@
 
 // TAKEN FROM PUB-SUB-CLIENT
 #include <functional>
-#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)>
+#define MQTT_CALLBACK_SIGNATURE_T std::function<void(char*, uint8_t*, unsigned int)>
 
 template <class modemType>
 class TinyGsmMqtt {
@@ -47,7 +47,7 @@ class TinyGsmMqtt {
   bool unsubscribeMqtt(uint8 connectId, uint16 msgId, String topic) {
     return thisModem().unsubscribeMqttImpl(connectId, msgId, topic);
   }
-  void setRecvCallbackMqtt(MQTT_CALLBACK_SIGNATURE callback) {
+  void setRecvCallbackMqtt(MQTT_CALLBACK_SIGNATURE_T callback) {
     thisModem().setRecvCallbackMqttImpl(callback);
   }
   void loopMqtt() {
@@ -77,7 +77,7 @@ class TinyGsmMqtt {
   bool subscribeMqttImpl(uint8 connectId, uint16 msgId, String topic, uint8 qos) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool unsubscribeMqttImpl(uint8 connectId, uint16 msgId, String topic) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool publishMqttImpl(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos, uint8 retain) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  void setRecvCallbackMqttImpl(MQTT_CALLBACK_SIGNATURE callback) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  void setRecvCallbackMqttImpl(MQTT_CALLBACK_SIGNATURE_T callback) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   void loopMqttImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
 };
 

--- a/src/TinyGsmMqtt.tpp
+++ b/src/TinyGsmMqtt.tpp
@@ -13,6 +13,9 @@
 
 #define TINY_GSM_MODEM_HAS_MQTT
 
+// TAKEN FROM PUB-SUB-CLIENT
+#include <functional>
+#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)>
 
 template <class modemType>
 class TinyGsmMqtt {
@@ -28,6 +31,27 @@ class TinyGsmMqtt {
   }
   bool connectMqtt(uint8 connectId, String clientname, String username = "", String password = "") {
     return thisModem().connectMqttImpl(connectId, clientname, username, password);
+  }
+  bool disconnectMqtt(uint8 connectId) {
+    return thisModem().disconnectMqttImpl(connectId);
+  }
+  bool closeMqtt(uint8 connectId) {
+    return thisModem().closeMqttImpl(connectId);
+  }
+  bool publishMqtt(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos = 0, uint8 retain = 0) {
+    return thisModem().publishMqttImpl(connectId, msgId, topic, msg, qos, retain);
+  }
+  bool subscribeMqtt(uint8 connectId, uint16 msgId, String topic, uint8 qos = 0) {
+    return thisModem().subscribeMqttImpl(connectId, msgId, topic, qos);
+  }
+  bool unsubscribeMqtt(uint8 connectId, uint16 msgId, String topic) {
+    return thisModem().unsubscribeMqttImpl(connectId, msgId, topic);
+  }
+  void setRecvCallbackMqtt(MQTT_CALLBACK_SIGNATURE callback) {
+    thisModem().setRecvCallbackMqttImpl(callback);
+  }
+  void loopMqtt() {
+    thisModem().loopMqttImpl();
   }
 
   /*
@@ -48,6 +72,13 @@ class TinyGsmMqtt {
   bool configureMqttImpl(String cmd, uint8 arg1, uint8 arg2, uint8 arg3, uint8 arg4) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool openMqttImpl(uint8 connectId, String servername, uint16 serverport) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool connectMqttImpl(uint8 connectId, String clientname, String username, String password) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool disconnectMqttImpl(uint8 connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool closeMqttImpl(uint8 connectId) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool subscribeMqttImpl(uint8 connectId, uint16 msgId, String topic, uint8 qos) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool unsubscribeMqttImpl(uint8 connectId, uint16 msgId, String topic) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool publishMqttImpl(uint8 connectId, uint16 msgId, String topic, String msg, uint8 qos, uint8 retain) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  void setRecvCallbackMqttImpl(MQTT_CALLBACK_SIGNATURE callback) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  void loopMqttImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
 };
 
 #endif  // SRC_TINYGSMSSL_H_

--- a/src/TinyGsmMqtt.tpp
+++ b/src/TinyGsmMqtt.tpp
@@ -1,0 +1,53 @@
+/**
+ * @file       TinyGsmMqtt.tpp
+ * @author     Clemens Arth
+ * @license    LGPL-3.0
+ * @copyright  Copyright (c) 2021 Clemens Arth
+ * @date       Jan 2021
+ */
+
+#ifndef SRC_TINYGSMMQTT_H_
+#define SRC_TINYGSMMQTT_H_
+
+#include "TinyGsmCommon.h"
+
+#define TINY_GSM_MODEM_HAS_MQTT
+
+
+template <class modemType>
+class TinyGsmMqtt {
+ public:
+  /*
+   * MQTT functions
+   */
+  bool configureMqtt(String cmd, uint8 arg1, uint8 arg2, uint8 arg3 = 0, uint8 arg4 = 0) {
+    return thisModem().configureMqttImpl(cmd, arg1, arg2, arg3, arg4);
+  }
+  bool openMqtt(uint8 connectId, String servername, uint16 serverport) {
+    return thisModem().openMqttImpl(connectId, servername, serverport);
+  }
+  bool connectMqtt(uint8 connectId, String clientname, String username = "", String password = "") {
+    return thisModem().connectMqttImpl(connectId, clientname, username, password);
+  }
+
+  /*
+   * CRTP Helper
+   */
+ protected:
+  inline const modemType& thisModem() const {
+    return static_cast<const modemType&>(*this);
+  }
+  inline modemType& thisModem() {
+    return static_cast<modemType&>(*this);
+  }
+
+  /*
+   * MQTT functions
+   */
+ protected:
+  bool configureMqttImpl(String cmd, uint8 arg1, uint8 arg2, uint8 arg3, uint8 arg4) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool openMqttImpl(uint8 connectId, String servername, uint16 serverport) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool connectMqttImpl(uint8 connectId, String clientname, String username, String password) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+};
+
+#endif  // SRC_TINYGSMSSL_H_

--- a/src/TinyGsmSSL.tpp
+++ b/src/TinyGsmSSL.tpp
@@ -29,7 +29,7 @@ class TinyGsmSSL {
   bool deleteCertificate() {
     return thisModem().deleteCertificateImpl();
   }
-  bool configureSSL(uint8 contextId, uint8 connectId, String cmd, uint8 arg = 0) {
+  bool configureSSL(uint8_t contextId, uint8_t connectId, String cmd, uint8_t arg = 0) {
     return thisModem().configureSSLImpl(contextId, connectId, cmd, arg);
   }
 
@@ -73,7 +73,7 @@ class TinyGsmSSL {
   bool addCertificateImpl(const char* filename) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool addCertificateAsStringImpl(String certificatestring) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool deleteCertificateImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool configureSSLImpl(uint8 contextId, uint8 connectId, String cmd) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool configureSSLImpl(uint8_t contextId, uint8_t connectId, String cmd) TINY_GSM_ATTR_NOT_IMPLEMENTED;
 };
 
 #endif  // SRC_TINYGSMSSL_H_

--- a/src/TinyGsmSSL.tpp
+++ b/src/TinyGsmSSL.tpp
@@ -23,8 +23,14 @@ class TinyGsmSSL {
   bool addCertificate(const char* filename) {
     return thisModem().addCertificateImpl(filename);
   }
+  bool addCertificateAsString(String certificatestring) {
+    return thisModem().addCertificateAsStringImpl(certificatestring);
+  }
   bool deleteCertificate() {
     return thisModem().deleteCertificateImpl();
+  }
+  bool configureSSL(uint8 contextId, uint8 connectId, String cmd, uint8 arg = 0) {
+    return thisModem().configureSSLImpl(contextId, connectId, cmd, arg);
   }
 
   /*
@@ -65,7 +71,9 @@ class TinyGsmSSL {
    */
  protected:
   bool addCertificateImpl(const char* filename) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool addCertificateAsStringImpl(String certificatestring) TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool deleteCertificateImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool configureSSLImpl(uint8 contextId, uint8 connectId, String cmd) TINY_GSM_ATTR_NOT_IMPLEMENTED;
 };
 
 #endif  // SRC_TINYGSMSSL_H_

--- a/src/TinyGsmTCP.tpp
+++ b/src/TinyGsmTCP.tpp
@@ -187,6 +187,7 @@ class TinyGsmTCP {
         } /* TODO: Read directly into user buffer? */
         at->maintain();
         if (sock_available > 0) {
+          // Serial.println("================ READNOCHECK ================");
           int n = at->modemRead(TinyGsmMin((uint16_t)rx.free(), sock_available),
                                 mux);
           if (n == 0) break;
@@ -217,6 +218,7 @@ class TinyGsmTCP {
         // TODO(vshymanskyy): Read directly into user buffer?
         at->maintain();
         if (sock_available > 0) {
+          // Serial.println("================ READWCHECK ================");
           int n = at->modemRead(TinyGsmMin((uint16_t)rx.free(), sock_available),
                                 mux);
           if (n == 0) break;
@@ -274,6 +276,7 @@ class TinyGsmTCP {
       uint32_t startMillis = millis();
       while (sock_available > 0 && (millis() - startMillis < maxWaitMs)) {
         rx.clear();
+        Serial.println("================ DUMP ================");
         at->modemRead(TinyGsmMin((uint16_t)rx.free(), sock_available), mux);
       }
       rx.clear();


### PR DESCRIPTION
Added Quectel BC66 support as UART modem (alpha stage)
- have fully functional MQTT client support
- have server-side SSL certificate validation support for MQTT client
- rudimentary connection/disconnection support based on original BG96 implementation (not fully tested)