### PR TITLE
FIX TinyGsmSequansMonarch::modemGetConnected status parsing

### DIFF
--- a/src/TinyGsmClientSequansMonarch.h
+++ b/src/TinyGsmClientSequansMonarch.h
@@ -585,7 +585,7 @@ class TinyGsmSequansMonarch
       //   DBG("### Warning: misaligned mux numbers!");
       // }
       streamSkipUntil(',');        // skip mux [use muxNo]
-      status = stream.parseInt();  // Read the status
+      status = stream.parseInt() - 48;  // Read the status and map ascii code to int
       // if mux is in use, will have comma then other info after the status
       // if not, there will be new line immediately after status
       // streamSkipUntil('\n'); // Skip port and IP info


### PR DESCRIPTION
Hi,

Using a Sequans Monarch modem (Pycom FiPy board) with TinyGsm has been problematic because : 

- in `TinyGsmSequansMonarch::modemGetConnected`, `stream.parseInt()` return the ascii code, not the real intended int
- when using a `TinyGsmClient` instance, passing a socket ID of 0 result in a panic during the firmware execution flow, wihout an access to an OpenOCD debugger, it seems that the `mux` handling is trying to map the wrong `<cid>` socket ID on the modem side

*Only the fix related to `TinyGsmSequansMonarch::modemGetConnected` is included in this pull request*