### PR TITLE
src/TinyGsmClientSequansMonarch.h: fix connection handling

### DIFF
--- a/src/TinyGsmClientSequansMonarch.h
+++ b/src/TinyGsmClientSequansMonarch.h
@@ -597,7 +597,7 @@ class TinyGsmSequansMonarch
       // SOCK_INCOMING               = 5,
       // SOCK_OPENING                = 6,
       GsmClientSequansMonarch* sock = sockets[mux % TINY_GSM_MUX_COUNT];
-      if (sock) {
+      if (sock && muxNo == mux) {
         sock->sock_connected = ((status != SOCK_CLOSED) &&
                                 (status != SOCK_INCOMING) &&
                                 (status != SOCK_OPENING));


### PR DESCRIPTION
There is an issue in the handling of `+SQNSS` answer: the `sock->sock_connected` state will always be set to the state of the last
socket. This will prevent any communication.

Fix this issue by checking that muxNo is equal to mux before updating.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>