### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "2.7"
+    - "3.6"
 
 # Cache PlatformIO packages using Travis CI container-based infrastructure
 #sudo: false


### PR DESCRIPTION
Fix for Travis CI.

The new version of PlatformIO ( issued by `platformio upgrade` in `.travis.yml` ) is dependent on Python 3
