### PR TITLE
fix bug for ussd answers over 127 chars

### DIFF
--- a/src/TinyGsmSMS.tpp
+++ b/src/TinyGsmSMS.tpp
@@ -73,7 +73,7 @@ class TinyGsmSMS {
 
   static inline String TinyGsmDecodeHex8bit(String& instr) {
     String result;
-    for (uint8_t i = 0; i < instr.length(); i += 2) {
+    for (uint16_t i = 0; i < instr.length(); i += 2) {
       char buf[4] = {
           0,
       };
@@ -87,7 +87,7 @@ class TinyGsmSMS {
 
   static inline String TinyGsmDecodeHex16bit(String& instr) {
     String result;
-    for (uint8_t i = 0; i < instr.length(); i += 4) {
+    for (uint16_t i = 0; i < instr.length(); i += 4) {
       char buf[4] = {
           0,
       };


### PR DESCRIPTION
Some telecom operators respond to a ussd request longer than 128 characters. In this case, we will not be able to exit the TinyGsmDecodeHex8bit function. It is necessary to change the declaration of the increment: "uint8_t i" -> "uint16_t i"
With function TinyGsmDecodeHex16bit i don't work, but for 16 bit messages we have only 64 char, if over, we never exit from this functions :)