### PR TITLE
Fix incorrect memory access in Sequans Monarch code

### DIFF
--- a/src/TinyGsmClientSequansMonarch.h
+++ b/src/TinyGsmClientSequansMonarch.h
@@ -98,7 +98,7 @@ class TinyGsmSequansMonarch
       } else {
         this->mux = (mux % TINY_GSM_MUX_COUNT) + 1;
       }
-      at->sockets[mux % TINY_GSM_MUX_COUNT] = this;
+      at->sockets[this->mux % TINY_GSM_MUX_COUNT] = this;
 
       return true;
     }


### PR DESCRIPTION
The mux value is corrected if it is out of the supported range, but the uncorrected value was used to store the connection object. This caused subsequent dereferences of the corrected mux index to access incorrect data or dereference a null pointer.