### PR TITLE
Add phone call implementation for SIM7600

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Watch this repo for new updates! And of course, contributions are welcome ;)
 
 **Voice Calls**
 - Supported on:
-    - SIM800/SIM900, A6/A7, Quectel modems, u-blox
+    - SIM800/SIM900, SIM7600, A6/A7, Quectel modems, u-blox
 - Not yet supported on:
-    - SIM7000, SIM5360/5320/7100, SIM7500/7600/7800, VZM20Q (Monarch)
+    - SIM7000, SIM5360/5320/7100, SIM7500/7800, VZM20Q (Monarch)
 - Not possible on:
     -  XBee (any type), u-blox SARA R4/N4, Neoway M590, ESP8266 (obviously)
 - Functions:

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -16,6 +16,7 @@
 #define TINY_GSM_BUFFER_READ_AND_CHECK_SIZE
 
 #include "TinyGsmBattery.tpp"
+#include "TinyGsmCalling.tpp"
 #include "TinyGsmGPRS.tpp"
 #include "TinyGsmGPS.tpp"
 #include "TinyGsmGSMLocation.tpp"
@@ -54,7 +55,8 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
                        public TinyGsmTime<TinyGsmSim7600>,
                        public TinyGsmNTP<TinyGsmSim7600>,
                        public TinyGsmBattery<TinyGsmSim7600>,
-                       public TinyGsmTemperature<TinyGsmSim7600> {
+                       public TinyGsmTemperature<TinyGsmSim7600>,
+                       public TinyGsmCalling<TinyGsmSim7600> {
   friend class TinyGsmModem<TinyGsmSim7600>;
   friend class TinyGsmGPRS<TinyGsmSim7600>;
   friend class TinyGsmTCP<TinyGsmSim7600, TINY_GSM_MUX_COUNT>;
@@ -65,6 +67,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
   friend class TinyGsmNTP<TinyGsmSim7600>;
   friend class TinyGsmBattery<TinyGsmSim7600>;
   friend class TinyGsmTemperature<TinyGsmSim7600>;
+  friend class TinyGsmCalling<TinyGsmSim7600>;
 
   /*
    * Inner Client
@@ -407,11 +410,10 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
    * Phone Call functions
    */
  protected:
-  bool callAnswerImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool callNumberImpl(const String& number) TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool callHangupImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
-  bool dtmfSendImpl(char cmd,
-                    int  duration_ms = 100) TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool callHangupImpl() {
+    sendAT(GF("+CHUP"));
+    return waitResponse() == 1;
+  }
 
   /*
    * Messaging functions


### PR DESCRIPTION
Add support for voice calls for SIM7600. This implements

* Answering calls
* Initiating calls
* Hanging up
* Sending DTMF tones
