### PR TITLE
BG96 SSL secure socket connection for AWS connection with certificates (in progress)

### DIFF
--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -77,6 +77,7 @@ typedef TinyGsmM95::GsmClientM95 TinyGsmClient;
 #include "TinyGsmClientBG96.h"
 typedef TinyGsmBG96                TinyGsm;
 typedef TinyGsmBG96::GsmClientBG96 TinyGsmClient;
+typedef TinyGsmBG96::GsmClientSecureBG96 TinyGsmClientSecure;
 
 #elif defined(TINY_GSM_MODEM_A6) || defined(TINY_GSM_MODEM_A7)
 #include "TinyGsmClientA6.h"


### PR DESCRIPTION
I noticed no-one seems to have has solved this problem yet. The challenge seems to come from how BG96 sets up SSL connection compared to other modems. Instead of using some AT command to configure SSL and then doing the rest with the TCP at commands, it has a whole set of different commands for SSL. This is tricky to integrate with how TinyGsm is currently structured.

I have redefined modemSend, modemRead, modemGetConnected and modemGetAvailable and felt like I almost got everything connected until I noticed that it is very difficult to make the TinyGsmTCP write and read functions call these functions of we are using GsmClientSecureBG96 instead of GsmClientBG96 without breaking core functionality for everything else.

I have also edited modemConnect and gprsConnectImpl but they seem to getting called correctly. 

My code compiles and runs. It creates a SSL context, but when it tries to read and write, it uses the wrong implementation (TCP) and fails.

Does anyone with a bit more insight into 
A. How I might complete what I have done so far so I can eventually pass an instance of the secure client into an mqtt client and connect to AWS iot (I can call the AT commands separately to load certs).
B. Some cheap hack way of making it work that breaks functionality for the other hardware implementations 
C. How TinyGsmSSL could be used for this purpose. It would be nice to avoid copying most of TinyGsmTCP. I suppose I could copy it and then pass flags through the modemSend, modemRead, modemGetConnected and modemGetAvailable calls and define the ssl AT logic in the TinyGsmBG96 versions of these instead of in the secure inner client.

Any help would be much appreciated!


