### PR TITLE
Fix handling response to CIPRXGET=4... request

### DIFF
--- a/src/TinyGsmClientSIM7000.h
+++ b/src/TinyGsmClientSIM7000.h
@@ -365,11 +365,15 @@ class TinyGsmSim7000 : public TinyGsmSim70xx<TinyGsmSim7000>,
 
     sendAT(GF("+CIPRXGET=4,"), mux);
     size_t result = 0;
-    if (waitResponse(GF("+CIPRXGET:")) == 1) {
-      streamSkipUntil(',');  // Skip mode 4
+    while (waitResponse(GF("+CIPRXGET:")) == 1) {
+      int8_t mode = streamGetIntBefore(',');
+      if (mode != 4) {
+        continue;
+      }
       streamSkipUntil(',');  // Skip mux
       result = streamGetIntBefore('\n');
       waitResponse();
+      break;
     }
     // DBG("### Available:", result, "on", mux);
     if (!result) { sockets[mux]->sock_connected = modemGetConnected(mux); }


### PR DESCRIPTION
Sim7000 can response with CIPRXGET 1,x for other mux, before answering with the needed CIPRXGET 4,x,y