### PR TITLE
Fixed modemGetAvailable() and modemGetConnected() when socket[0] is no connected

### DIFF
--- a/src/TinyGsmClientSIM7000SSL.h
+++ b/src/TinyGsmClientSIM7000SSL.h
@@ -497,7 +497,6 @@ class TinyGsmSim7000SSL
       }
 
       if (!anySocketConnected) {
-        log_w("No sockets connected");
         return 0;
       }
 


### PR DESCRIPTION
Both methods update status of all connections, but guards at the beginning would return 0 when socket[0] was not connected