### PR TITLE
Gps start modes

### DIFF
--- a/src/TinyGsmClientBG96.h
+++ b/src/TinyGsmClientBG96.h
@@ -326,7 +326,7 @@ class TinyGsmBG96 : public TinyGsmModem<TinyGsmBG96>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     sendAT(GF("+QGPS=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientBG96.h
+++ b/src/TinyGsmClientBG96.h
@@ -326,7 +326,7 @@ class TinyGsmBG96 : public TinyGsmModem<TinyGsmBG96>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     sendAT(GF("+QGPS=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM70xx.h
+++ b/src/TinyGsmClientSIM70xx.h
@@ -278,7 +278,7 @@ class TinyGsmSim70xx : public TinyGsmModem<TinyGsmSim70xx<modemType>>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     thisModem().sendAT(GF("+CGNSPWR=1"));
     if (thisModem().waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM70xx.h
+++ b/src/TinyGsmClientSIM70xx.h
@@ -278,7 +278,7 @@ class TinyGsmSim70xx : public TinyGsmModem<TinyGsmSim70xx<modemType>>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     thisModem().sendAT(GF("+CGNSPWR=1"));
     if (thisModem().waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -433,6 +433,12 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
  protected:
   // enable GPS
   bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
+    switch (startMode) {
+      case GPS_START_COLD: sendAT(GF("+CGPSCOLD")); break;
+      case GPS_START_HOT: sendAT(GF("+CGPSHOT")); break;
+      default: sendAT(); break;
+    }
+    if (waitResponse() != 1) { return false; }
     sendAT(GF("+CGPS=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -432,7 +432,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     sendAT(GF("+CGPS=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -432,7 +432,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
    */
  protected:
   // enable GPS
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     sendAT(GF("+CGPS=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -27,7 +27,7 @@ class TinyGsmSim808 : public TinyGsmSim800, public TinyGsmGPS<TinyGsmSim808>, pu
    */
  protected:
   // enable GPS
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     sendAT(GF("+CGNSPWR=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -32,11 +32,8 @@ class TinyGsmSim808 : public TinyGsmSim800, public TinyGsmGPS<TinyGsmSim808>, pu
 
     switch (startMode) {
       case GPS_START_COLD: iStartMode = 0; break;
-
       case GPS_START_HOT: iStartMode = 1; break;
-
       case GPS_START_WARM: iStartMode = 2; break;
-
       default: break;
     }
 

--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -27,7 +27,7 @@ class TinyGsmSim808 : public TinyGsmSim800, public TinyGsmGPS<TinyGsmSim808>, pu
    */
  protected:
   // enable GPS
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     sendAT(GF("+CGNSPWR=1"));
     if (waitResponse() != 1) { return false; }
     return true;

--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -28,23 +28,15 @@ class TinyGsmSim808 : public TinyGsmSim800, public TinyGsmGPS<TinyGsmSim808>, pu
  protected:
   // enable GPS
   bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
-    uint8_t iStartMode = 0;
-
-    switch (startMode) {
-      case GPS_START_COLD: iStartMode = 0; break;
-      case GPS_START_HOT: iStartMode = 1; break;
-      case GPS_START_WARM: iStartMode = 2; break;
-      default: break;
-    }
-
     sendAT(GF("+CGNSPWR=1"));
     if (waitResponse() != 1) { return false; }
-
-    if (startMode != GPS_START_AUTO) {
-      sendAT(GF("+CGPSRST="), iStartMode);
-      if (waitResponse() != 1) { return false; }
+    switch (startMode) {
+      case GPS_START_COLD: sendAT(GF("+CGPSRST="), 0); break;
+      case GPS_START_HOT: sendAT(GF("+CGPSRST="), 1); break;
+      case GPS_START_WARM: sendAT(GF("+CGPSRST="), 2); break;
+      default: return true;
     }
-
+    if (waitResponse() != 1) { return false; }
     return true;
   }
 

--- a/src/TinyGsmClientSIM808.h
+++ b/src/TinyGsmClientSIM808.h
@@ -28,8 +28,26 @@ class TinyGsmSim808 : public TinyGsmSim800, public TinyGsmGPS<TinyGsmSim808>, pu
  protected:
   // enable GPS
   bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
+    uint8_t iStartMode = 0;
+
+    switch (startMode) {
+      case GPS_START_COLD: iStartMode = 0; break;
+
+      case GPS_START_HOT: iStartMode = 1; break;
+
+      case GPS_START_WARM: iStartMode = 2; break;
+
+      default: break;
+    }
+
     sendAT(GF("+CGNSPWR=1"));
     if (waitResponse() != 1) { return false; }
+
+    if (startMode != GPS_START_AUTO) {
+      sendAT(GF("+CGPSRST="), iStartMode);
+      if (waitResponse() != 1) { return false; }
+    }
+
     return true;
   }
 

--- a/src/TinyGsmClientSaraR4.h
+++ b/src/TinyGsmClientSaraR4.h
@@ -434,7 +434,7 @@ class TinyGsmSaraR4 : public TinyGsmModem<TinyGsmSaraR4>,
    * I2C port, the GSM-based "Cell Locate" location will be returned instead.
    */
  protected:
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     // AT+UGPS=<mode>[,<aid_mode>[,<GNSS_systems>]]
     // <mode> - 0: GNSS receiver powered off, 1: on
     // <aid_mode> - 0: no aiding (default)

--- a/src/TinyGsmClientSaraR4.h
+++ b/src/TinyGsmClientSaraR4.h
@@ -434,7 +434,7 @@ class TinyGsmSaraR4 : public TinyGsmModem<TinyGsmSaraR4>,
    * I2C port, the GSM-based "Cell Locate" location will be returned instead.
    */
  protected:
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     // AT+UGPS=<mode>[,<aid_mode>[,<GNSS_systems>]]
     // <mode> - 0: GNSS receiver powered off, 1: on
     // <aid_mode> - 0: no aiding (default)

--- a/src/TinyGsmClientUBLOX.h
+++ b/src/TinyGsmClientUBLOX.h
@@ -434,7 +434,7 @@ class TinyGsmUBLOX : public TinyGsmModem<TinyGsmUBLOX>,
    * I2C port, the GSM-based "Cell Locate" location will be returned instead.
    */
  protected:
-  bool enableGPSImpl() {
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
     // AT+UGPS=<mode>[,<aid_mode>[,<GNSS_systems>]]
     // <mode> - 0: GNSS receiver powered off, 1: on
     // <aid_mode> - 0: no aiding (default)

--- a/src/TinyGsmClientUBLOX.h
+++ b/src/TinyGsmClientUBLOX.h
@@ -434,7 +434,7 @@ class TinyGsmUBLOX : public TinyGsmModem<TinyGsmUBLOX>,
    * I2C port, the GSM-based "Cell Locate" location will be returned instead.
    */
  protected:
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO) {
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO) {
     // AT+UGPS=<mode>[,<aid_mode>[,<GNSS_systems>]]
     // <mode> - 0: GNSS receiver powered off, 1: on
     // <aid_mode> - 0: no aiding (default)

--- a/src/TinyGsmGPS.tpp
+++ b/src/TinyGsmGPS.tpp
@@ -13,14 +13,21 @@
 
 #define TINY_GSM_MODEM_HAS_GPS
 
+enum GpsStartMode {
+  GPS_START_AUTO = 0,
+  GPS_START_COLD = 1,
+  GPS_START_WARM = 2,
+  GPS_START_HOT  = 3,
+};
+
 template <class modemType>
 class TinyGsmGPS {
  public:
   /*
    * GPS/GNSS/GLONASS location functions
    */
-  bool enableGPS() {
-    return thisModem().enableGPSImpl();
+  bool enableGPS(GpsStartMode start_mode = GPS_START_AUTO) {
+    return thisModem().enableGPSImpl(start_mode);
   }
   bool disableGPS() {
     return thisModem().disableGPSImpl();
@@ -66,7 +73,8 @@ class TinyGsmGPS {
    * GPS/GNSS/GLONASS location functions
    */
 
-  bool    enableGPSImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
+  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO)
+      TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool    disableGPSImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
   String  getGPSrawImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool    getGPSImpl(float* lat, float* lon, float* speed = 0, float* alt = 0,

--- a/src/TinyGsmGPS.tpp
+++ b/src/TinyGsmGPS.tpp
@@ -26,8 +26,8 @@ class TinyGsmGPS {
   /*
    * GPS/GNSS/GLONASS location functions
    */
-  bool enableGPS(GpsStartMode start_mode = GPS_START_AUTO) {
-    return thisModem().enableGPSImpl(start_mode);
+  bool enableGPS(GpsStartMode startMode = GPS_START_AUTO) {
+    return thisModem().enableGPSImpl(startMode);
   }
   bool disableGPS() {
     return thisModem().disableGPSImpl();
@@ -73,7 +73,7 @@ class TinyGsmGPS {
    * GPS/GNSS/GLONASS location functions
    */
 
-  bool enableGPSImpl(GpsStartMode start_mode = GPS_START_AUTO)
+  bool enableGPSImpl(GpsStartMode startMode = GPS_START_AUTO)
       TINY_GSM_ATTR_NOT_IMPLEMENTED;
   bool    disableGPSImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;
   String  getGPSrawImpl() TINY_GSM_ATTR_NOT_IMPLEMENTED;


### PR DESCRIPTION
Some modules have an option to tell the GPS how to start.
This can speed up position acquisition.
Implemented for SIM7600 and SIM808.
Tested on SIM7600E and SIM868.