### PR TITLE
Fix cheacking ip status in Neoway M590

### DIFF
--- a/src/TinyGsmClientM590.h
+++ b/src/TinyGsmClientM590.h
@@ -330,9 +330,10 @@ class TinyGsmM590 : public TinyGsmModem<TinyGsmM590>,
   }
 
   bool modemGetConnected(uint8_t mux) {
-    sendAT(GF("+CIPSTATUS="), mux);
-    int8_t res = waitResponse(GF(",\"CONNECTED\""), GF(",\"CLOSED\""),
+    sendAT(GF("+IPSTATUS="), mux);
+    int8_t res = waitResponse(GF(",CONNECT,"), GF(",DISCONNECT"),
                               GF(",\"CLOSING\""), GF(",\"INITIAL\""));
+    streamSkipUntil('\n');
     waitResponse();
     return 1 == res;
   }


### PR DESCRIPTION
There is no `CIPSTATUS` command in the documentation https://cyntech.co.uk/downloads/neoway-m590-at-command-sets-v3.pdf, instead there is an `IPSTATUS` command