### PR TITLE
Fix NTPServerSync

### DIFF
--- a/src/TinyGsmClientSIM7000.h
+++ b/src/TinyGsmClientSIM7000.h
@@ -17,11 +17,13 @@
 
 #include "TinyGsmClientSIM70xx.h"
 #include "TinyGsmTCP.tpp"
-
+#include "TinyGsmNTP.tpp"
 
 class TinyGsmSim7000 : public TinyGsmSim70xx<TinyGsmSim7000>,
+                       public TinyGsmNTP<TinyGsmSim7000>,
                        public TinyGsmTCP<TinyGsmSim7000, TINY_GSM_MUX_COUNT> {
   friend class TinyGsmSim70xx<TinyGsmSim7000>;
+  friend class TinyGsmNTP<TinyGsmSim7000>;
   friend class TinyGsmTCP<TinyGsmSim7000, TINY_GSM_MUX_COUNT>;
 
   /*

--- a/src/TinyGsmClientSIM7000SSL.h
+++ b/src/TinyGsmClientSIM7000SSL.h
@@ -18,13 +18,16 @@
 #include "TinyGsmClientSIM70xx.h"
 #include "TinyGsmTCP.tpp"
 #include "TinyGsmSSL.tpp"
+#include "TinyGsmNTP.tpp"
 
 class TinyGsmSim7000SSL
     : public TinyGsmSim70xx<TinyGsmSim7000SSL>,
       public TinyGsmTCP<TinyGsmSim7000SSL, TINY_GSM_MUX_COUNT>,
+      public TinyGsmNTP<TinyGsmSim7000SSL>,
       public TinyGsmSSL<TinyGsmSim7000SSL> {
   friend class TinyGsmSim70xx<TinyGsmSim7000SSL>;
   friend class TinyGsmTCP<TinyGsmSim7000SSL, TINY_GSM_MUX_COUNT>;
+  friend class TinyGsmNTP<TinyGsmSim7000SSL>;
   friend class TinyGsmSSL<TinyGsmSim7000SSL>;
 
   /*

--- a/src/TinyGsmClientSIM7000SSL.h
+++ b/src/TinyGsmClientSIM7000SSL.h
@@ -245,7 +245,7 @@ class TinyGsmSim7000SSL
     //                 2: CHAP
     //                 3: PAP or CHAP
     if (pwd && strlen(pwd) > 0 && user && strlen(user) > 0) {
-      sendAT(GF("+CNCFG=1,\""), apn, "\",\"", "\",\"", user, pwd, '"');
+      sendAT(GF("+CNCFG=1,\""), apn, "\",\"", "\",\"", user, pwd, "\",3");
       waitResponse();
     } else if (user && strlen(user) > 0) {
       // Set the user name only

--- a/src/TinyGsmClientSIM7080.h
+++ b/src/TinyGsmClientSIM7080.h
@@ -18,11 +18,14 @@
 #include "TinyGsmClientSIM70xx.h"
 #include "TinyGsmTCP.tpp"
 #include "TinyGsmSSL.tpp"
+#include "TinyGsmNTP.tpp"
 
 class TinyGsmSim7080 : public TinyGsmSim70xx<TinyGsmSim7080>,
+                       public TinyGsmNTP<TinyGsmSim7080>,
                        public TinyGsmTCP<TinyGsmSim7080, TINY_GSM_MUX_COUNT>,
                        public TinyGsmSSL<TinyGsmSim7080> {
   friend class TinyGsmSim70xx<TinyGsmSim7080>;
+  friend class TinyGsmNTP<TinyGsmSim7080>;
   friend class TinyGsmTCP<TinyGsmSim7080, TINY_GSM_MUX_COUNT>;
   friend class TinyGsmSSL<TinyGsmSim7080>;
 
@@ -317,7 +320,45 @@ class TinyGsmSim7080 : public TinyGsmSim70xx<TinyGsmSim7080>,
   /*
    * NTP server functions
    */
-  // Can sync with server using CNTP as per template
+
+  byte NTPServerSyncImpl(String server = "pool.ntp.org", int TimeZone = 0) {
+    // Set GPRS bearer profile to associate with NTP sync
+    // this may fail, it's not supported by all modules
+    sendAT(GF("+CNTPCID=0")); // CID must be 0. With 1 (like other modules) does not work!
+    waitResponse(10000L);
+
+    // Set NTP server and timezone
+    sendAT(GF("+CNTP=\""), server, "\",", String(TimeZone));
+    if (waitResponse(10000L) != 1) { return -1; }
+
+    // Request network synchronization
+    sendAT(GF("+CNTP"));
+    if (waitResponse(10000L, GF("+CNTP:"))) {
+      String result = stream.readStringUntil('\n');
+      // Check for ',' in case the module appends the time next to the return code. Eg: +CNTP: <code>[,<time>]
+      int index = result.indexOf(',');
+      if(index > 0) {
+          result.remove(index);
+      }
+      result.trim();
+      if (TinyGsmIsValidNumber(result)) { return result.toInt(); }
+    } else {
+      return -1;
+    }
+    return -1;
+  }
+
+  String ShowNTPErrorImpl(byte error) {
+    switch (error) {
+      case 1: return "Network time synchronization is successful";
+      case 61: return "Network error";
+      case 62: return "DNS resolution error";
+      case 63: return "Connection error";
+      case 64: return "Service response error";
+      case 65: return "Service response timeout";
+      default: return "Unknown error: " + String(error);
+    }
+  }
 
   /*
    * Battery functions

--- a/src/TinyGsmClientSIM7080.h
+++ b/src/TinyGsmClientSIM7080.h
@@ -250,7 +250,7 @@ class TinyGsmSim7080 : public TinyGsmSim70xx<TinyGsmSim7080>,
     //                  2: CHAP
     //                  3: PAP or CHAP
     if (pwd && strlen(pwd) > 0 && user && strlen(user) > 0) {
-      sendAT(GF("+CNCFG=0,1,\""), apn, "\",\"", user, "\",\"", pwd, '"');
+      sendAT(GF("+CNCFG=0,1,\""), apn, "\",\"", user, "\",\"", pwd, "\",3");
       waitResponse();
     } else if (user && strlen(user) > 0) {
       // Set the user name only

--- a/src/TinyGsmClientSIM70xx.h
+++ b/src/TinyGsmClientSIM70xx.h
@@ -18,7 +18,6 @@
 #include "TinyGsmModem.tpp"
 #include "TinyGsmSMS.tpp"
 #include "TinyGsmTime.tpp"
-#include "TinyGsmNTP.tpp"
 #include "TinyGsmGSMLocation.tpp"
 
 #define GSM_NL "\r\n"
@@ -45,7 +44,6 @@ class TinyGsmSim70xx : public TinyGsmModem<TinyGsmSim70xx<modemType>>,
                        public TinyGsmSMS<TinyGsmSim70xx<modemType>>,
                        public TinyGsmGPS<TinyGsmSim70xx<modemType>>,
                        public TinyGsmTime<TinyGsmSim70xx<modemType>>,
-                       public TinyGsmNTP<TinyGsmSim70xx<modemType>>,
                        public TinyGsmBattery<TinyGsmSim70xx<modemType>>,
                        public TinyGsmGSMLocation<TinyGsmSim70xx<modemType>> {
   friend class TinyGsmModem<TinyGsmSim70xx<modemType>>;
@@ -53,7 +51,6 @@ class TinyGsmSim70xx : public TinyGsmModem<TinyGsmSim70xx<modemType>>,
   friend class TinyGsmSMS<TinyGsmSim70xx<modemType>>;
   friend class TinyGsmGPS<TinyGsmSim70xx<modemType>>;
   friend class TinyGsmTime<TinyGsmSim70xx<modemType>>;
-  friend class TinyGsmNTP<TinyGsmSim70xx<modemType>>;
   friend class TinyGsmBattery<TinyGsmSim70xx<modemType>>;
   friend class TinyGsmGSMLocation<TinyGsmSim70xx<modemType>>;
 

--- a/src/TinyGsmNTP.tpp
+++ b/src/TinyGsmNTP.tpp
@@ -32,7 +32,7 @@ class TinyGsmNTP {
     return true;
   }
 
-  byte NTPServerSync(String server = "pool.ntp.org", byte TimeZone = 3) {
+  byte NTPServerSync(String server = "pool.ntp.org", int TimeZone = 0) {
     return thisModem().NTPServerSyncImpl(server, TimeZone);
   }
   String ShowNTPError(byte error) {
@@ -54,7 +54,7 @@ class TinyGsmNTP {
    * NTP server functions
    */
  protected:
-  byte NTPServerSyncImpl(String server = "pool.ntp.org", byte TimeZone = 3) {
+  byte NTPServerSyncImpl(String server = "pool.ntp.org", int TimeZone = 0) {
     // Set GPRS bearer profile to associate with NTP sync
     // this may fail, it's not supported by all modules
     thisModem().sendAT(GF("+CNTPCID=1"));
@@ -68,6 +68,11 @@ class TinyGsmNTP {
     thisModem().sendAT(GF("+CNTP"));
     if (thisModem().waitResponse(10000L, GF("+CNTP:"))) {
       String result = thisModem().stream.readStringUntil('\n');
+      // Check for ',' in case the modules appends the time nexto to the return value.
+      int index = result.indexOf(',');
+      if(index > 0) {
+          result.remove(index);
+      }
       result.trim();
       if (TinyGsmIsValidNumber(result)) { return result.toInt(); }
     } else {

--- a/src/TinyGsmNTP.tpp
+++ b/src/TinyGsmNTP.tpp
@@ -68,7 +68,7 @@ class TinyGsmNTP {
     thisModem().sendAT(GF("+CNTP"));
     if (thisModem().waitResponse(10000L, GF("+CNTP:"))) {
       String result = thisModem().stream.readStringUntil('\n');
-      // Check for ',' in case the modules appends the time nexto to the return value.
+      // Check for ',' in case the module appends the time next to the return code. Eg: +CNTP: <code>[,<time>]
       int index = result.indexOf(',');
       if(index > 0) {
           result.remove(index);


### PR DESCRIPTION
Hello @SRGDamia1 @vshymanskyy thank you for your great work.

This PR fixes two issues with the NTPServerSync function.

1) Prior to this PR, you could not set negative timezones because the passed value was byte (which translates to uin8_t). Now the value passed it's an Int so you can set any timezone (from -47 to +48).

2) On old SIM800 the return code of +CNTP was always: `+CNTP: <code>` but now with newer modules you could also get the network time attached to the response like this: `+CNTP: <code>[,<time>]` . What I did to keep backward compatibility is to look for the ',' and remove all the leading characters if found. If not, assume the reply was just the `<code>`.

It is working perfectly on my SIM7000. 

Thanks
Gonzalo
