### PR TITLE
password then user when cid is set

### DIFF
--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -316,7 +316,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
 
     // Set the external authentication
     if (user && strlen(user) > 0) {
-      sendAT(GF("+CGAUTH=1,0,\""), user, GF("\",\""), pwd, '"');
+      sendAT(GF("+CGAUTH=1,0,\""), pwd, GF("\",\""), user, '"');
       waitResponse();
     }
 


### PR DESCRIPTION
<img width="485" alt="Screen Shot 2022-08-24 at 13 03 55" src="https://user-images.githubusercontent.com/809378/186327053-35b88705-585b-4983-8142-b933ccbf63c6.png">


https://www.simcom.com/product/SIM7600X-PCIE.html
SIM7500_SIM7600 Series_AT Command Manual_V3.00

- `AT+CGAUTH=<cid>[,<auth_type>[,<passwd>[,<user>]]]`
- `AT+CGAUTH=,,<user>,<passwd> (for CDMA1x-EvDo)`

If not CDMA1, password should come first.

