### PR TITLE
Update CNCFG for SIM7000SSL

### DIFF
--- a/src/TinyGsmClientSIM7000SSL.h
+++ b/src/TinyGsmClientSIM7000SSL.h
@@ -242,7 +242,7 @@ class TinyGsmSim7000SSL
     //                 2: CHAP
     //                 3: PAP or CHAP
     if (pwd && strlen(pwd) > 0 && user && strlen(user) > 0) {
-      sendAT(GF("+CNCFG=1,\""), apn, "\",\"", "\",\"", user, pwd, '"');
+      sendAT(GF("+CNCFG=1,\""), apn, "\",\"",user, "\",\"", pwd, '"');
       waitResponse();
     } else if (user && strlen(user) > 0) {
       // Set the user name only


### PR DESCRIPTION
the user and the password are together and need to be separate to work the command AT. Without this change was not working.