### PR TITLE
SIM7600 Protocol enhancements (Fixes #624)

### DIFF
--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -230,7 +230,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     if (!testAT()) { return false; }
     sendAT(GF("+CRESET"));
     if (waitResponse(10000L) != 1) { return false; }
-    delay(24000L)
+    delay(24000L);
     return init(pin);
   }
 

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -121,7 +121,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     }
 
     /*
-     * Extended API
+     * Exended API
      */
 
     String remoteIP() TINY_GSM_ATTR_NOT_IMPLEMENTED;
@@ -506,11 +506,9 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
       ialt   = streamGetFloatBefore(',');  // MSL Altitude. Unit is meters
       ispeed = streamGetFloatBefore(',');  // Speed Over Ground. Unit is knots.
       streamSkipUntil(',');                // Course Over Ground. Degrees.
-      streamSkipUntil(',');  // After set, will report GPS every x seconds
       iaccuracy = streamGetFloatBefore(',');  // Position Dilution Of Precision
       streamSkipUntil(',');   // Horizontal Dilution Of Precision
-      streamSkipUntil(',');   // Vertical Dilution Of Precision
-      streamSkipUntil('\n');  // TODO(?) is one more field reported??
+      streamSkipUntil('\n');  // Vertical Dilution Of Precision
 
       // Set pointers
       if (lat != NULL)

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -121,7 +121,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     }
 
     /*
-     * Exended API
+     * Extended API
      */
 
     String remoteIP() TINY_GSM_ATTR_NOT_IMPLEMENTED;
@@ -230,7 +230,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     if (!testAT()) { return false; }
     sendAT(GF("+CRESET"));
     if (waitResponse(10000L) != 1) { return false; }
-    delay(24000L);
+    delay(24000L)
     return init(pin);
   }
 

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -230,7 +230,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     if (!testAT()) { return false; }
     sendAT(GF("+CRESET"));
     if (waitResponse(10000L) != 1) { return false; }
-    delay(5000L);  // TODO(?):  Test this delay!
+    delay(24000L);
     return init(pin);
   }
 


### PR DESCRIPTION
1. SIM7600 delay in `restartImpl()` is not enough, a real module takes at least 23 seconds to reboot before it starts to respond to any AT commands.
2. (Fixes #624) The `getGPSImpl(...)` method expects two extra `","` in the response that breaks the `iaccuracy` variable and also causes it to skip the `OK` part in the end of the response that leads to the 3-seconds waiting until the timeout occurs. After that the `waitResponse()` in the last line of that method also does not receive the proper `OK` and also waits 1 extra second until the timeout.

![image](https://github.com/vshymanskyy/TinyGSM/assets/96617154/af232bfc-e0e9-4f54-8219-3283538ca13d)