### PR TITLE
Fix cardinal points in location by gps for sim7600

### DIFF
--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -482,15 +482,13 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
       int   imin         = 0;
       float secondWithSS = 0;
 
-      streamSkipUntil(',');               // GPS satellite valid numbers
-      streamSkipUntil(',');               // GLONASS satellite valid numbers
-      streamSkipUntil(',');               // BEIDOU satellite valid numbers
-      ilat  = streamGetFloatBefore(',');  // Latitude in ddmm.mmmmmm
-      north = stream.read();              // N/S Indicator, N=north or S=south
-      streamSkipUntil(',');
-      ilon = streamGetFloatBefore(',');  // Longitude in ddmm.mmmmmm
-      east = stream.read();              // E/W Indicator, E=east or W=west
-      streamSkipUntil(',');
+      streamSkipUntil(',');                           // GPS satellite valid numbers
+      streamSkipUntil(',');                           // GLONASS satellite valid numbers
+      streamSkipUntil(',');                           // BEIDOU satellite valid numbers
+      ilat  = streamGetFloatBefore(',');              // Latitude in ddmm.mmmmmm
+      north = stream.readStringUntil(',').charAt(0);  // N/S Indicator, N=north or S=south
+      ilon  = streamGetFloatBefore(',');              // Longitude in ddmm.mmmmmm
+      east  = stream.readStringUntil(',').charAt(0);  // E/W Indicator, E=east or W=west
 
       // Date. Output format is ddmmyy
       iday   = streamGetIntLength(2);    // Two digit day


### PR DESCRIPTION
In the sim7600 modem, when the location is being obtained recurrently from the second iteration, it does not process the cardinal points correctly.
![Fix cardinal points in location by gps for modem sim7600](https://github.com/vshymanskyy/TinyGSM/assets/13054229/916083da-14ea-4df9-8e80-12fbb2068478)

https://github.com/vshymanskyy/TinyGSM/issues/566

https://github.com/vshymanskyy/TinyGSM/issues/641