### PR TITLE
Fix SIM7600 error on send data of > 1400 bytes

### DIFF
--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -1,27 +1,34 @@
 /**
- * @file       TinyGsmClientSIM7600.h
- * @author     Volodymyr Shymanskyy
- * @license    LGPL-3.0
- * @copyright  Copyright (c) 2016 Volodymyr Shymanskyy
- * @date       Nov 2016
- */
+            std::int16_t ret = 0;
+        constexpr std::size_t max_len = 1400;
 
-#ifndef SRC_TINYGSMCLIENTSIM7600_H_
-#define SRC_TINYGSMCLIENTSIM7600_H_
+        std::uint8_t cursor_buffer[max_len] = {0};
+     auto buff_convert = reinterpret_cast<const std::uint8_t *>(buff); // TODO: Get the real max of hardware
+        for (size_t cursor = 0; cursor < len; cursor += max_l{
+       const size_t to_send = std::min(max_len, len - cursor);  
+        sendAT(GF(
+    // Only send data in chunks"+CIPSEND="), mux, ',', (uint16_t)to_send) ;
+        if (waitResponse(GF(">"cursor)) != 1) { return 0; 
+      std::copy(buff_convert + cursor, buff_convert + cursor + to_send, cursor_buffer);
+        stream.write(cursor_buffer, to_send);
+         stream.flush();
 
-// #define TINY_GSM_DEBUG Serial
-// #define TINY_GSM_USE_HEX
+      if (waitResponse(GF(GSM_NL "+CIPSEND:")) != 1) { return 0; }
+       streamSkipUntil(',');  // Skip mux
+            streamSkipUntil(',');  // Skip requested bytes to send
+       ret = streamGetIntBefore('\n');
+        }
+   return ret;
+fine TINY_GSM_USE_HEX
 
-#define TINY_GSM_MUX_COUNT 10
+e TINY_GSM_MUX_COUNT 10
 #define TINY_GSM_BUFFER_READ_AND_CHECK_SIZE
-
-#include "TinyGsmBattery.tpp"
-#include "TinyGsmCalling.tpp"
+ude "TinyGsmBattery.tpp"
+de "TinyGsmCalling.tpp"
 #include "TinyGsmGPRS.tpp"
-#include "TinyGsmGPS.tpp"
-#include "TinyGsmGSMLocation.tpp"
+de "TinyGsmGPS.tppnclude "TinyGsmGSMLocation.tpp"
 #include "TinyGsmModem.tpp"
-#include "TinyGsmSMS.tpp"
+#include "TinyGsmSpp"
 #include "TinyGsmTCP.tpp"
 #include "TinyGsmTemperature.tpp"
 #include "TinyGsmTime.tpp"
@@ -644,15 +651,34 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
   }
 
   int16_t modemSend(const void* buff, size_t len, uint8_t mux) {
-    sendAT(GF("+CIPSEND="), mux, ',', (uint16_t)len);
-    if (waitResponse(GF(">")) != 1) { return 0; }
-    stream.write(reinterpret_cast<const uint8_t*>(buff), len);
-    stream.flush();
-    if (waitResponse(GF(GSM_NL "+CIPSEND:")) != 1) { return 0; }
-    streamSkipUntil(',');  // Skip mux
-    streamSkipUntil(',');  // Skip requested bytes to send
-    // TODO(?):  make sure requested and confirmed bytes match
-    return streamGetIntBefore('\n');
+    std::int16_t ret = 0;
+    constexpr std::size_t max_len = 1400; // TODO: Get the real max of hardware
+
+    std::uint8_t cursor_buffer[max_len];
+    auto buff_convert = reinterpret_cast<const std::uint8_t *>(buff);
+
+    // Only send data in chunks
+    for (size_t cursor = 0; cursorsor < len; cursor += max_len)
+    {
+      const size_t to_send = std::min(max_len, len - cursor);
+
+      sendAT(GF("+CIPSEND="), mux, ',', (uint16_t)to_send);
+      if (waitResponse(GF(">")) != 1) { return 0; }
+
+      std::copy(buff_convert + cursor, buff_convert + cursor + to_send, cursor_buffer);
+
+      stream.write(cursor_buffer, to_send);
+      stream.flush();
+
+      if (waitResponse(GF(GSM_NL "+CIPSEND:")) != 1) { return 0; }
+
+      streamSkipUntil(',');  // Skip mux
+      streamSkipUntil(',');  // Skip requested bytes to send
+
+      ret = streamGetIntBefore('\n');
+    }
+
+    return ret;
   }
 
   size_t modemRead(size_t size, uint8_t mux) {


### PR DESCRIPTION
When you try to send data > Ethernet Frame default MTU (1500) the SIM7600 responds with CIPERROR 3. This method is used too by the HTTPClient interface, so you can't send POST or other HTTP queries that exceed that size.
This PR fix that trying to split the full data array into chunks.