### PR TITLE
Avoid unnecessary timeout when receiving "SEND FAIL" response from SIM7000 modem

### DIFF
--- a/src/TinyGsmClientSIM7000.h
+++ b/src/TinyGsmClientSIM7000.h
@@ -306,7 +306,7 @@ class TinyGsmSim7000 : public TinyGsmSim70xx<TinyGsmSim7000>,
     stream.write(reinterpret_cast<const uint8_t*>(buff), len);
     stream.flush();
 
-    if (waitResponse(GF(GSM_NL "DATA ACCEPT:")) != 1) { return 0; }
+    if (waitResponse(GF(GSM_NL "DATA ACCEPT:"),GF("SEND FAIL")) != 1) { return 0; }
     streamSkipUntil(',');  // Skip mux
     return streamGetIntBefore('\n');
   }

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -291,6 +291,17 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     return waitResponse() == 1;
   }
 
+  bool getNetworkSystemMode(bool& n, int16_t& stat) {
+    // n: whether to automatically report the system mode info
+    // stat: the current service. 0 if it not connected
+    sendAT(GF("+CNSMOD?"));
+    if (waitResponse(GF(GSM_NL "+CNSMOD:")) != 1) { return false; }
+    n    = streamGetIntBefore(',') != 0;
+    stat = streamGetIntBefore('\n');
+    waitResponse();
+    return true;
+  }
+
   String getLocalIPImpl() {
     sendAT(GF("+IPADDR"));  // Inquire Socket PDP address
     // sendAT(GF("+CGPADDR=1"));  // Show PDP address

--- a/src/TinyGsmModem.tpp
+++ b/src/TinyGsmModem.tpp
@@ -29,8 +29,8 @@ class TinyGsmModem {
     thisModem().stream.flush();
     TINY_GSM_YIELD(); /* DBG("### AT:", cmd...); */
   }
-  void setBaud(uint32_t baud) {
-    thisModem().setBaudImpl(baud);
+  bool setBaud(uint32_t baud) {
+    return thisModem().setBaudImpl(baud);
   }
   // Test response to AT commands
   bool testAT(uint32_t timeout_ms = 10000L) {
@@ -106,10 +106,10 @@ class TinyGsmModem {
    * Basic functions
    */
  protected:
-  void setBaudImpl(uint32_t baud) {
+  bool setBaudImpl(uint32_t baud) {
     thisModem().sendAT(GF("+IPR="), baud);
-    thisModem().waitResponse();
-  }
+    return thisModem().waitResponse() == 1;
+  } 
 
   bool testATImpl(uint32_t timeout_ms = 10000L) {
     for (uint32_t start = millis(); millis() - start < timeout_ms;) {


### PR DESCRIPTION
Add support for "SEND FAIL" response from SIM7000 modem

Without this change the transmission pauses for 1 second when "SEND FAIL" is received from the modem as the code ends up in the unhandled case in waitResponse() after the default 1 second timeout. This significantly reduces the possible throughput.