### PR TITLE
SIM7600 SSL support 🤯

### DIFF
--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -55,6 +55,7 @@ typedef TinyGsmSim5360::GsmClientSim5360 TinyGsmClient;
 #include "TinyGsmClientSIM7600.h"
 typedef TinyGsmSim7600                   TinyGsm;
 typedef TinyGsmSim7600::GsmClientSim7600 TinyGsmClient;
+typedef TinyGsmSim7600::GsmClientSecureSim7600 TinyGsmClientSecure;
 
 #elif defined(TINY_GSM_MODEM_UBLOX)
 #include "TinyGsmClientUBLOX.h"


### PR DESCRIPTION
# What

Native SSL support for the SIM7600. Use in the same way you would for 7080:
```cpp
#define TINY_GSM_MODEM_SIM7600
TinyGsm modem(SerialAT);
TinyGsmClientSecure client(modem, 0);  // be sure to only use mux 0 or 1, it's all the chip allows!
HttpClient http(client, SERVER, PORT);
```

In your runtime code, before making any requests, you may need to add
```cpp
        client.setCertificate(AWS_CERT_CA);  // e.g. static const char AWS_CERT_CA[] PROGMEM = R"EOF(BEGIN CERTIFICATE-----...
```

You DO NOT! need any additional SSL libraries for this code to work!

# Tested On

- HTTPS GET thanks to `HttpsClient.ino` example
- HTTPS GET and POST thanks to custom code to [wiremockapi](wiremockapi.cloud)
- HTTPS OTA update from AWS S3 bucket using custom code (happy to share on request)

# Known/Suspected Bugs

- Doesn't work on Beeceptor HTTPS (works fine on HTTP). Maybe I'm using the wrong certs, I've tried a few options.
- Haven't tested using both MUXs (you can have up to 2 HTTPS connections, in theory)
- Haven't tried mix-and-matching HTTPS and HTTP connections, which SIMCOM reckons you can do.
- Sorry if linting/formatting isn't on-point. My cpp linter did not like your layout at all 😂