### PR TITLE
Identfy the "+CIPRXGET: 4" response for the "AT+CIPRXGET=4,0" command, even if modem returns "+CIPRXGET: 1" and "+CIPRXGET: 4" in the same response

### DIFF
--- a/src/TinyGsmClientSIM7000.h
+++ b/src/TinyGsmClientSIM7000.h
@@ -412,9 +412,16 @@ class TinyGsmSim7000 : public TinyGsmSim70xx<TinyGsmSim7000>,
 
     sendAT(GF("+CIPRXGET=4,"), mux);
     size_t result = 0;
+
     if (waitResponse(GF("+CIPRXGET:")) == 1) {
-      streamSkipUntil(',');  // Skip mode 4
+      int16_t first_mode_to_appear = streamGetIntBefore(','); // Skip and get first mode to appear
+
       streamSkipUntil(',');  // Skip mux
+
+      if (first_mode_to_appear == 1) {
+        streamSkipUntil(','); // Skip last comma, if appears +CIPRXGET: 1,0 first than +CIPRXGET: 4 in response
+      }
+
       result = streamGetIntBefore('\n');
       waitResponse();
     }


### PR DESCRIPTION
Sometimes, the SIM7000 modem returns "+CIPRXGET: 1" and "+CIPRXGET: 4" in the same response, if you execute CIPSTATUS before than "AT+CIPRXGET=4,0".

In the expected cenario, the modem returns "+CIPRXGET: 1,0" in CIPSTATUS response (Figure 1).

![Figure 1](https://github.com/vshymanskyy/TinyGSM/assets/55090803/cd5513e8-40b8-4f02-acf2-3eff6fe644b8)

But, in some cases, the modem returns  "+CIPRXGET: 1,0" only in "AT+CIPRXGET=4,0" response (Figure 2). In this cenario, the "modemGetAvailable" funcion can't identify the  "+CIPRXGET: 4" response.

![Figure 2](https://github.com/vshymanskyy/TinyGSM/assets/55090803/87edfa03-0966-4252-bda0-e829dd5f95c8)



