### PR TITLE
Fix IMEI query for SIM76XX series

### DIFF
--- a/src/TinyGsmClientSIM70xx.h
+++ b/src/TinyGsmClientSIM70xx.h
@@ -228,6 +228,16 @@ class TinyGsmSim70xx : public TinyGsmModem<SIM70xxType>,
     return res;
   }
 
+  // Gets the IMEI of the modem with AT+CGSN
+  String getIMEIImpl() {
+    sendAT(GF("+CGSN"));
+    if (waitResponse(GF(AT_NL)) != 1) { return ""; }
+    String res = stream.readStringUntil('\n');
+    waitResponse();
+    res.trim();
+    return res;
+  }
+
   /*
    * GPS/GNSS/GLONASS location functions
    */

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -412,8 +412,10 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     return res;
   }
 
+  // Gets the IMEI of the modem with AT+CGSN
   String getIMEIImpl() {
     sendAT(GF("+CGSN"));
+    if (waitResponse(GF(AT_NL)) != 1) { return ""; }
     String res = stream.readStringUntil('\n');
     waitResponse();
     res.trim();

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -412,6 +412,14 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     return res;
   }
 
+  String getIMEIImpl() {
+    sendAT(GF("+CGSN"));
+    String res = stream.readStringUntil('\n');
+    waitResponse();
+    res.trim();
+    return res;
+  }
+
   /*
    * Phone Call functions
    */


### PR DESCRIPTION
Why:

- Allow IMEI to be queried

This change addresses the need by:

- Adding custom IMEI query with AT+CGSN command

Testing with a SIMCOM INCORPORATED A7672G-LABE.