### PR TITLE
feat: add configurable timeouts for TCP commands ( #844 )

### DIFF
--- a/src/TinyGsmClientSIM5360.h
+++ b/src/TinyGsmClientSIM5360.h
@@ -350,12 +350,12 @@ class TinyGsmSim5360 : public TinyGsmModem<TinyGsmSim5360>,
     // AsyncMode = sets mode of executing commands
     //           = 0 (synchronous command executing)
     // TimeoutVal = minimum retransmission timeout in milliseconds = 75000
-    sendAT(GF("+CIPCCFG=10,0,0,0,1,0,75000"));
+    sendAT(GF("+CIPCCFG=10,0,0,0,1,0," TINY_GSM_STRINGIFY(TINY_GSM_TCP_RTX_TIMEOUT_MS)));
     if (waitResponse() != 1) { return false; }
 
     // Configure timeouts for opening and closing sockets
     // AT+CIPTIMEOUT=<netopen_timeout>, <cipopen_timeout>, <cipsend_timeout>
-    sendAT(GF("+CIPTIMEOUT="), 75000, ',', 15000, ',', 15000);
+    sendAT(GF("+CIPTIMEOUT="), TINY_GSM_NETOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPSEND_TIMEOUT_MS);
     waitResponse();
 
     // Start the socket service
@@ -366,7 +366,7 @@ class TinyGsmSim5360 : public TinyGsmModem<TinyGsmSim5360>,
     // We to ignore any immediate response and wait for the
     // URC to show it's really connected.
     sendAT(GF("+NETOPEN"));
-    if (waitResponse(75000L, GF(AT_NL "+NETOPEN: 0")) != 1) { return false; }
+    if (waitResponse(TINY_GSM_NETOPEN_TIMEOUT_MS, GF(AT_NL "+NETOPEN: 0")) != 1) { return false; }
 
     return true;
   }
@@ -382,7 +382,7 @@ class TinyGsmSim5360 : public TinyGsmModem<TinyGsmSim5360>,
     // Note: all sockets should be closed first - on 3G/4G models the sockets
     // must be closed manually
     sendAT(GF("+NETCLOSE"));
-    if (waitResponse(60000L, GF(AT_NL "+NETCLOSE: 0")) != 1) { return false; }
+    if (waitResponse(TINY_GSM_NETCLOSE_TIMEOUT_MS, GF(AT_NL "+NETCLOSE: 0")) != 1) { return false; }
 
     return true;
   }

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -345,12 +345,12 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     // AsyncMode = sets mode of executing commands
     //           = 0 (synchronous command executing)
     // TimeoutVal = minimum retransmission timeout in milliseconds = 75000
-    sendAT(GF("+CIPCCFG=10,0,0,0,1,0,75000"));
+    sendAT(GF("+CIPCCFG=10,0,0,0,1,0," TINY_GSM_STRINGIFY(TINY_GSM_TCP_RTX_TIMEOUT_MS)));
     if (waitResponse() != 1) { return false; }
 
     // Configure timeouts for opening and closing sockets
     // AT+CIPTIMEOUT=<netopen_timeout> <cipopen_timeout>, <cipsend_timeout>
-    sendAT(GF("+CIPTIMEOUT="), 75000, ',', 15000, ',', 15000);
+    sendAT(GF("+CIPTIMEOUT="), TINY_GSM_NETOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPOPEN_TIMEOUT_MS, ',', TINY_GSM_TCP_TX_TIMEOUT_MS);
     waitResponse();
 
     // Start the socket service
@@ -361,7 +361,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     // We to ignore any immediate response and wait for the
     // URC to show it's really connected.
     sendAT(GF("+NETOPEN"));
-    if (waitResponse(75000L, GF(AT_NL "+NETOPEN: 0")) != 1) { return false; }
+    if (waitResponse(TINY_GSM_NETOPEN_TIMEOUT_MS, GF(AT_NL "+NETOPEN: 0")) != 1) { return false; }
 
     return true;
   }
@@ -371,7 +371,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     // Note: On the LTE models, this single command closes all sockets and the
     // service
     sendAT(GF("+NETCLOSE"));
-    if (waitResponse(60000L, GF(AT_NL "+NETCLOSE: 0")) != 1) { return false; }
+    if (waitResponse(TINY_GSM_NETCLOSE_TIMEOUT_MS, GF(AT_NL "+NETCLOSE: 0")) != 1) { return false; }
 
     return true;
   }

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -350,7 +350,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
 
     // Configure timeouts for opening and closing sockets
     // AT+CIPTIMEOUT=<netopen_timeout> <cipopen_timeout>, <cipsend_timeout>
-    sendAT(GF("+CIPTIMEOUT="), TINY_GSM_NETOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPOPEN_TIMEOUT_MS, ',', TINY_GSM_TCP_TX_TIMEOUT_MS);
+    sendAT(GF("+CIPTIMEOUT="), TINY_GSM_NETOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPOPEN_TIMEOUT_MS, ',', TINY_GSM_CIPSEND_TIMEOUT_MS);
     waitResponse();
 
     // Start the socket service

--- a/src/TinyGsmCommon.h
+++ b/src/TinyGsmCommon.h
@@ -28,6 +28,30 @@
 #include <Client.h>
 #endif
 
+#define _TINY_GSM_STRINGIFY(x) #x
+#define TINY_GSM_STRINGIFY(x) _TINY_GSM_STRINGIFY(x)
+
+#ifndef TINY_GSM_NETOPEN_TIMEOUT_MS
+#define TINY_GSM_NETOPEN_TIMEOUT_MS 75000
+#endif
+
+#ifndef TINY_GSM_NETCLOSE_TIMEOUT_MS
+#define TINY_GSM_NETCLOSE_TIMEOUT_MS 75000
+#endif
+
+/* minimum retransmission timeout value for TCP connection */
+#ifndef TINY_GSM_TCP_RTX_TIMEOUT_MS
+#define TINY_GSM_TCP_RTX_TIMEOUT_MS 75000
+#endif
+
+#ifndef TINY_GSM_CIPOPEN_TIMEOUT_MS
+#define TINY_GSM_CIPOPEN_TIMEOUT_MS 15000
+#endif 
+
+#ifndef TINY_GSM_CIPSEND_TIMEOUT_MS
+#define TINY_GSM_CIPSEND_TIMEOUT_MS 15000
+#endif 
+
 #ifndef TINY_GSM_YIELD_MS
 #define TINY_GSM_YIELD_MS 0
 #endif

--- a/src/TinyGsmTCP.tpp
+++ b/src/TinyGsmTCP.tpp
@@ -26,10 +26,10 @@
     return connect(TinyGsmStringFromIp(ip).c_str(), port, timeout_s); \
   }                                                                   \
   int connect(const char* host, uint16_t port) override {             \
-    return connect(host, port, 75);                                   \
+    return connect(host, port, (TINY_GSM_CIPOPEN_TIMEOUT_MS / 1000)); \
   }                                                                   \
   int connect(IPAddress ip, uint16_t port) override {                 \
-    return connect(ip, port, 75);                                     \
+    return connect(ip, port, (TINY_GSM_CIPOPEN_TIMEOUT_MS / 1000));   \
   }
 
 // // For modules that do not store incoming data in any sort of buffer


### PR DESCRIPTION
added compilation definitions with default values in TinyGsmCommon.h to be used with TCP AT commands:
 - TINY_GSM_NETOPEN_TIMEOUT_MS 75000
 - TINY_GSM_NETCLOSE_TIMEOUT_MS 75000
 - TINY_GSM_TCP_RTX_TIMEOUT_MS 75000
 - TINY_GSM_CIPOPEN_TIMEOUT_MS 15000
 - TINY_GSM_CIPSEND_TIMEOUT_MS 15000

Can be overridden before compilation. If no definition is given, the default value is used. Also, modified TinyGsmClientIM7600.h and TinyGsmClientSIM5360.h to use those definitions.

I have a question about the `TINY_GSM_CONNECT_OVERRIDES`, the overrides use connect with a timeout of 75 seconds, but when opening a TCP connection, it's configured with a different timeout value for CIPOPEN. is there a reason why `connect` waits response for a longer time than CIPOPEN timeout ?